### PR TITLE
Add generic Handler trait for typed dispatch

### DIFF
--- a/src/typed.rs
+++ b/src/typed.rs
@@ -7,6 +7,22 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::HashMap;
 use may_minihttp::Request;
 
+/// Trait implemented by typed coroutine handlers.
+///
+/// A handler receives a [`TypedHandlerRequest`] and returns a typed response.
+pub trait Handler<TReq, TRes>: Send + 'static {
+    fn handle(&self, req: TypedHandlerRequest<TReq>) -> TRes;
+}
+
+impl<TReq, TRes, F> Handler<TReq, TRes> for F
+where
+    F: Fn(TypedHandlerRequest<TReq>) -> TRes + Send + Sync + 'static,
+{
+    fn handle(&self, req: TypedHandlerRequest<TReq>) -> TRes {
+        (self)(req)
+    }
+}
+
 
 pub trait TypedHandlerFor<T>: Sized {
     fn from_handler(req: HandlerRequest) -> TypedHandlerRequest<T>;
@@ -31,17 +47,18 @@ pub struct TypedHandlerResponse<T: Serialize> {
 }
 
 impl Dispatcher {
-    /// Register a typed handler that deserializes the body into `TReq` and responds with `TRes`
-    pub unsafe fn register_typed<TReq, TRes, F>(&mut self, name: &str, handler_fn: F)
+    /// Register a typed handler that deserializes the body into `TReq` and responds with `TRes`.
+    pub unsafe fn register_typed<TReq, TRes, H>(&mut self, name: &str, handler: H)
     where
         TReq: DeserializeOwned + Send + 'static,
         TRes: Serialize + Send + 'static,
-        F: Fn(TypedHandlerRequest<TReq>) -> TRes + Send + 'static + Clone,
+        H: Handler<TReq, TRes> + Send + 'static,
     {
         let (tx, rx) = mpsc::channel::<HandlerRequest>();
         let name = name.to_string();
 
         may::coroutine::spawn(move || {
+            let handler = handler;
             for req in rx.iter() {
                 let data: TReq = match req.body {
                     Some(json) => match serde_json::from_value(json) {
@@ -77,7 +94,7 @@ impl Dispatcher {
                     data,
                 };
 
-                let result = handler_fn(typed_req);
+                let result = handler.handle(typed_req);
 
                 let _ = req.reply_tx.send(HandlerResponse {
                     status: 200,

--- a/templates/controller.rs.txt
+++ b/templates/controller.rs.txt
@@ -1,17 +1,21 @@
 {# controller.rs.txt #}
 // User-owned controller for handler '{{ handler_name }}'.
 
-use crate::brrtrouter::typed::TypedHandlerRequest;
+use crate::brrtrouter::typed::{TypedHandlerRequest, Handler};
 use crate::handlers::{{ handler_name }}::{ Request, Response };
 
-pub fn handle(_req: TypedHandlerRequest<Request>) -> Response {
-    {% if has_example %}
-    // Example response:
-    // {{ example_json | indent(4) }}
-    {% endif %}
-    Response {
-        {% for field in response_fields %}
-        {{ field.name }}: {{ field.value }},
-        {% endfor %}
+pub struct {{ struct_name }};
+
+impl Handler<Request, Response> for {{ struct_name }} {
+    fn handle(&self, _req: TypedHandlerRequest<Request>) -> Response {
+        {% if has_example %}
+        // Example response:
+        // {{ example_json | indent(8) }}
+        {% endif %}
+        Response {
+            {% for field in response_fields %}
+            {{ field.name }}: {{ field.value }},
+            {% endfor %}
+        }
     }
 }

--- a/templates/registry.rs.txt
+++ b/templates/registry.rs.txt
@@ -2,21 +2,14 @@
 // Auto-generated handler registry
 
 use brrtrouter::dispatcher::Dispatcher;
+use crate::controllers::*;
 use crate::handlers::*;
-
-{% for entry in entries -%}
-use crate::handlers::{{ entry.name }}::IntoTypedRequest;
-use crate::handlers::{{ entry.name }}::{{ entry.request_type }};
-{% endfor %}
 
 pub unsafe fn register_all(dispatcher: &mut Dispatcher) {
     {% for entry in entries -%}
-    dispatcher.register_handler("{{ entry.name }}", |req| {
-        {{ entry.name }}::handler(
-            brrtrouter::typed::TypedHandlerRequest::<{{ entry.request_type }}>::from(
-                req.into_typed_request(),
-            ),
-        );
-    });
+    dispatcher.register_typed(
+        "{{ entry.name }}",
+        crate::controllers::{{ entry.name }}::{{ entry.controller_struct }},
+    );
     {% endfor %}
 }


### PR DESCRIPTION
## Summary
- define `Handler<TReq, TRes>` trait for typed handlers
- register any `Handler` in `Dispatcher::register_typed`
- generate controllers implementing the new trait
- simplify registry to register typed controllers

## Testing
- `cargo test -- --nocapture` *(fails: Could not connect to crates.io)*