### PR TITLE
Fix routing for root path

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -55,6 +55,13 @@ impl Router {
     }
 
     fn path_to_regex(path: &str) -> (Regex, Vec<String>) {
+        if path == "/" {
+            return (
+                Regex::new(r"^/$").expect("Failed to compile path regex"),
+                Vec::new(),
+            );
+        }
+
         let mut pattern = String::from("^");
         let mut param_names = Vec::new();
 

--- a/tests/router_tests.rs
+++ b/tests/router_tests.rs
@@ -12,6 +12,11 @@ info:
   title: Verb Zoo
   version: "1.0.0"
 paths:
+  "/":
+    get:
+      x-handler-root: root_handler
+      responses:
+        "200": { description: OK }
   /zoo/animals:
     get:
       x-handler-get: get_animals
@@ -159,4 +164,11 @@ fn test_router_unknown_path() {
     let routes = parse_spec(example_spec());
     let router = Router::new(routes);
     assert_route_match(&router, Method::GET, "/unknown", "<none>");
+}
+
+#[test]
+fn test_router_root_path() {
+    let routes = parse_spec(example_spec());
+    let router = Router::new(routes);
+    assert_route_match(&router, Method::GET, "/", "root_handler");
 }


### PR DESCRIPTION
## Summary
- fix regex generation when path is `/`
- add test coverage for `/`

## Testing
- `cargo test -- --nocapture` *(fails: could not download crates)*