### PR TITLE
Fix Router::new signature

### DIFF
--- a/examples/pet_store/src/main.rs
+++ b/examples/pet_store/src/main.rs
@@ -12,7 +12,7 @@ fn main() -> io::Result<()> {
     let (routes, _slug) = brrtrouter::spec::load_spec("examples/pet_store/openapi.yaml", false)
         .expect("failed to load OpenAPI spec");
 
-    let router = Router::new((routes, String::new()));
+    let router = Router::new(routes);
     let mut dispatcher = Dispatcher::new();
     unsafe {
         registry::register_all(&mut dispatcher);

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,8 @@ use std::io;
 
 fn main() -> io::Result<()> {
     // Load OpenAPI spec and create router
-    let spec = load_spec("examples/openapi.yaml", false).expect("failed to load spec");
-    let router = Router::new(spec);
+    let (routes, _slug) = load_spec("examples/openapi.yaml", false).expect("failed to load spec");
+    let router = Router::new(routes);
 
     // Create dispatcher and register handlers
     let mut dispatcher = Dispatcher::new();

--- a/src/router.rs
+++ b/src/router.rs
@@ -19,7 +19,7 @@ pub struct Router {
 }
 
 impl Router {
-    pub fn new((routes, _handler_prefix): Vec<RouteMeta>) -> Self {
+    pub fn new(routes: Vec<RouteMeta>) -> Self {
         // Filter out routes that are not HTTP methods we care about
         // We only support GET, POST, PUT, DELETE, PATCH, and OPTIONS
         let supported_methods = vec![

--- a/templates/main.rs.txt
+++ b/templates/main.rs.txt
@@ -12,7 +12,7 @@ fn main() -> io::Result<()> {
     let (routes, _slug) = brrtrouter::spec::load_spec("examples/{{ name }}/openapi.yaml", false)
         .expect("failed to load OpenAPI spec");
 
-    let router = Router::new((routes, String::new()));
+    let router = Router::new(routes);
     let mut dispatcher = Dispatcher::new();
     unsafe {
         registry::register_all(&mut dispatcher);


### PR DESCRIPTION
## Summary
- simplify Router constructor to take only `Vec<RouteMeta>`
- update main example and template to match new signature
- adjust pet_store example

## Testing
- `cargo test --quiet` *(fails: could not download crates)*