### PR TITLE
Fix parameter extraction usage in build_routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    env:
+      BRRTR_LOCAL: "1"
 
     steps:
       - name: Checkout code

--- a/examples/pet_store/src/handlers/types.rs
+++ b/examples/pet_store/src/handlers/types.rs
@@ -3,28 +3,26 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct ListUsersResponse {
-    pub users: Vec<User>,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct Pet {
-    pub age: i32,
-    pub breed: String,
+pub struct PetCreationResponse {
     pub id: i32,
+    pub status: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct GetItemResponse {
+    pub id: String,
     pub name: String,
-    pub tags: Vec<serde_json::Value>,
-    pub vaccinated: bool,
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct ListUserPostsResponse {
-    pub items: Vec<Post>,
+pub struct Item {
+    pub id: String,
+    pub name: String,
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct AdminSettingsResponse {
-    pub feature_flags: serde_json::Value,
+pub struct AddPetRequest {
+    pub name: String,
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -33,49 +31,10 @@ pub struct AdminSettings {
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct CreateItemRequest {
-    pub name: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct User {
-    pub id: String,
-    pub name: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct PetCreationResponse {
-    pub id: i32,
-    pub status: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct AddPetResponse {
-    pub id: i32,
-    pub status: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct GetPostResponse {
+pub struct Post {
     pub body: String,
     pub id: String,
     pub title: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct PostItemRequest {
-    pub name: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct CreatePetRequest {
-    pub name: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct PostItemResponse {
-    pub id: String,
-    pub name: String,
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -89,16 +48,53 @@ pub struct GetPetResponse {
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct GetUserResponse {
+pub struct UserList {
+    pub users: Vec<User>,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct GetPostResponse {
+    pub body: String,
+    pub id: String,
+    pub title: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Pet {
+    pub age: i32,
+    pub breed: String,
+    pub id: i32,
+    pub name: String,
+    pub tags: Vec<serde_json::Value>,
+    pub vaccinated: bool,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct AddPetResponse {
+    pub id: i32,
+    pub status: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct PostItemResponse {
     pub id: String,
     pub name: String,
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct Post {
-    pub body: String,
+pub struct User {
     pub id: String,
-    pub title: String,
+    pub name: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct CreateItemRequest {
+    pub name: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct AdminSettingsResponse {
+    pub feature_flags: serde_json::Value,
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -107,23 +103,27 @@ pub struct ListPetsResponse {
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct UserList {
+pub struct GetUserResponse {
+    pub id: String,
+    pub name: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct ListUserPostsResponse {
+    pub items: Vec<Post>,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct ListUsersResponse {
     pub users: Vec<User>,
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct GetItemResponse {
-    pub id: String,
+pub struct CreatePetRequest {
     pub name: String,
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct AddPetRequest {
-    pub name: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct Item {
-    pub id: String,
+pub struct PostItemRequest {
     pub name: String,
     }

--- a/examples/pet_store/src/main.rs
+++ b/examples/pet_store/src/main.rs
@@ -20,14 +20,9 @@ fn main() -> io::Result<()> {
 
     let service = AppService { router, dispatcher };
 
-    let addr = if std::env::var("BRRTR_LOCAL").is_ok() {
-        "127.0.0.1:8080"
-    } else {
-        "0.0.0.0:8080"
-    };
-    println!("🚀 pet_store example server listening on {addr}");
+    println!("🚀 pet_store example server listening on 0.0.0.0:8080");
     let server = HttpServer(service)
-        .start(addr)
+        .start("0.0.0.0:8080")
         .map_err(io::Error::other)?;
 
     server

--- a/examples/pet_store/src/main.rs
+++ b/examples/pet_store/src/main.rs
@@ -20,9 +20,14 @@ fn main() -> io::Result<()> {
 
     let service = AppService { router, dispatcher };
 
-    println!("🚀 pet_store example server listening on 0.0.0.0:8080");
+    let addr = if std::env::var("BRRTR_LOCAL").is_ok() {
+        "127.0.0.1:8080"
+    } else {
+        "0.0.0.0:8080"
+    };
+    println!("🚀 pet_store example server listening on {addr}");
     let server = HttpServer(service)
-        .start("0.0.0.0:8080")
+        .start(addr)
         .map_err(io::Error::other)?;
 
     server

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ pub fn run_cli() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
     match &cli.command {
         Commands::Generate { spec, force } => {
-            let (routes, slug) = load_spec(spec.to_str().unwrap(), false)?;
+            let (_routes, _slug) = load_spec(spec.to_str().unwrap())?;
             crate::generator::generate_project_from_spec(spec.as_path(), *force)
                 .expect("failed to generate example project");
             Ok(())

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -86,7 +86,7 @@ pub struct ControllerTemplateData {
 }
 
 pub fn generate_project_from_spec(spec_path: &Path, force: bool) -> anyhow::Result<()> {
-    let (mut routes, slug) = load_spec(spec_path.to_str().unwrap(), false)?;
+    let (mut routes, slug) = load_spec(spec_path.to_str().unwrap())?;
     let base_dir = Path::new("examples").join(&slug);
     let src_dir = base_dir.join("src");
     let handler_dir = src_dir.join("handlers");

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::io;
 
 fn main() -> io::Result<()> {
     // Load OpenAPI spec and create router
-    let (routes, _slug) = load_spec("examples/openapi.yaml", false).expect("failed to load spec");
+    let (routes, _slug) = load_spec("examples/openapi.yaml").expect("failed to load spec");
     let router = Router::new(routes);
 
     // Create dispatcher and register handlers

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,13 +16,19 @@ fn main() -> io::Result<()> {
     //     registry::register_all(&mut dispatcher);
     // }
 
-    // Start the HTTP server on port 8080 (0.0.0.0:8080) under the may runtime
+    // Start the HTTP server on port 8080, binding to 127.0.0.1 if BRRTR_LOCAL is
+    // set for local testing.
     // This returns a coroutine JoinHandle; we join on it to keep the server running
     let service = AppService { router, dispatcher };
+    let addr = if std::env::var("BRRTR_LOCAL").is_ok() {
+        "127.0.0.1:8080"
+    } else {
+        "0.0.0.0:8080"
+    };
     let server = HttpServer(service)
-        .start("0.0.0.0:8080")
+        .start(addr)
         .map_err(io::Error::other)?;
-    println!("Server started successfully on 0.0.0.0:8080");
+    println!("Server started successfully on {addr}");
     server
         .join()
         .map_err(|e| io::Error::other(format!("Server encountered an error: {:?}", e)))?;

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -183,7 +183,7 @@ fn resolve_parameter_ref<'a>(
 
 fn extract_parameters(
     spec: &OpenApiV3Spec,
-    params: &Vec<ObjectOrReference<Parameter>>,
+    params: &Option<Vec<ObjectOrReference<Parameter>>>,
 ) -> Vec<ParameterMeta> {
     let mut out = Vec::new();
     if let Some(list) = params {
@@ -204,7 +204,7 @@ fn extract_parameters(
 
                 out.push(ParameterMeta {
                     name: param.name.clone(),
-                    location: String::from(param.location.to_owned()),
+                    location: format!("{:?}", param.location),
                     required: param.required.is_some(),
                     schema,
                 });

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -163,6 +163,58 @@ fn extract_response_schema_and_example(
         .unwrap_or((None, None))
 }
 
+fn resolve_parameter_ref<'a>(
+    spec: &'a OpenApiV3Spec,
+    ref_path: &str,
+) -> Option<&'a oas3::spec::Parameter> {
+    if let Some(name) = ref_path.strip_prefix("#/components/parameters/") {
+        spec.components
+            .as_ref()?
+            .parameters
+            .as_ref()?
+            .get(name)
+            .and_then(|param_ref| match param_ref {
+                ObjectOrReference::Object(param) => Some(param),
+                _ => None,
+            })
+    } else {
+        None
+    }
+}
+
+fn extract_parameters(
+    spec: &OpenApiV3Spec,
+    params: &Option<Vec<oas3::spec::ObjectOrReference<oas3::spec::Parameter>>>,
+) -> Vec<ParameterMeta> {
+    let mut out = Vec::new();
+    if let Some(list) = params {
+        for p in list {
+            let param = match p {
+                ObjectOrReference::Object(obj) => Some(obj),
+                ObjectOrReference::Ref { ref_path } => resolve_parameter_ref(spec, ref_path),
+            };
+
+            if let Some(param) = param {
+                let schema = param.schema.as_ref().and_then(|s| match s {
+                    ObjectOrReference::Object(obj) => serde_json::to_value(obj).ok(),
+                    ObjectOrReference::Ref { ref_path } => {
+                        resolve_schema_ref(spec, ref_path)
+                            .and_then(|sch| serde_json::to_value(sch).ok())
+                    }
+                });
+
+                out.push(ParameterMeta {
+                    name: param.name.clone(),
+                    location: param.location.clone(),
+                    required: param.required,
+                    schema,
+                });
+            }
+        }
+    }
+    out
+}
+
 pub fn build_routes(
     spec: &OpenApiV3Spec,
     verbose: bool,
@@ -186,11 +238,15 @@ pub fn build_routes(
                 let (response_schema, example) =
                     extract_response_schema_and_example(spec, operation);
 
+                let mut parameters = Vec::new();
+                parameters.extend(extract_parameters(spec, &item.parameters));
+                parameters.extend(extract_parameters(spec, &operation.parameters));
+
                 routes.push(RouteMeta {
                     method,
                     path_pattern: path.clone(),
                     handler_name,
-                    parameters: vec![],
+                    parameters,
                     request_schema,
                     response_schema,
                     example,

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -183,32 +183,30 @@ fn resolve_parameter_ref<'a>(
 
 fn extract_parameters(
     spec: &OpenApiV3Spec,
-    params: &Option<Vec<ObjectOrReference<Parameter>>>,
+    params: &Vec<ObjectOrReference<Parameter>>,
 ) -> Vec<ParameterMeta> {
     let mut out = Vec::new();
-    if let Some(list) = params {
-        for p in list {
+    for p in params {
             let param = match p {
                 ObjectOrReference::Object(obj) => Some(obj),
                 ObjectOrReference::Ref { ref_path } => resolve_parameter_ref(spec, &ref_path),
             };
 
-            if let Some(param) = param {
-                let schema = param.schema.as_ref().and_then(|s| match s {
-                    ObjectOrReference::Object(obj) => serde_json::to_value(obj).ok(),
-                    ObjectOrReference::Ref { ref_path } => {
-                        resolve_schema_ref(spec, ref_path)
-                            .and_then(|sch| serde_json::to_value(sch).ok())
-                    }
-                });
+        if let Some(param) = param {
+            let schema = param.schema.as_ref().and_then(|s| match s {
+                ObjectOrReference::Object(obj) => serde_json::to_value(obj).ok(),
+                ObjectOrReference::Ref { ref_path } => {
+                    resolve_schema_ref(spec, ref_path)
+                        .and_then(|sch| serde_json::to_value(sch).ok())
+                }
+            });
 
-                out.push(ParameterMeta {
-                    name: param.name.clone(),
-                    location: format!("{:?}", param.location),
-                    required: param.required.is_some(),
-                    schema,
-                });
-            }
+            out.push(ParameterMeta {
+                name: param.name.clone(),
+                location: format!("{:?}", param.location),
+                required: param.required.is_some(),
+                schema,
+            });
         }
     }
     out

--- a/tests/router_tests.rs
+++ b/tests/router_tests.rs
@@ -63,11 +63,11 @@ paths:
 
 fn parse_spec(yaml: &str) -> Vec<RouteMeta> {
     let spec = serde_yaml::from_str(yaml).expect("failed to parse YAML spec");
-    brrtrouter::spec::load_spec_from_spec(spec, false).expect("failed to load spec")
+    brrtrouter::spec::load_spec_from_spec(spec).expect("failed to load spec")
 }
 
 pub fn load_spec_from_spec(spec_wrapper: oas3::OpenApiV3Spec) -> anyhow::Result<Vec<RouteMeta>> {
-    brrtrouter::spec::load_spec_from_spec(spec_wrapper, false)
+    brrtrouter::spec::load_spec_from_spec(spec_wrapper)
 }
 
 fn assert_route_match(router: &Router, method: Method, path: &str, expected_handler: &str) {


### PR DESCRIPTION
## Summary
- add resolve_parameter_ref and implement extract_parameters
- include path and operation parameters in `build_routes`
- default bind address honors `BRRTR_LOCAL` env variable in `src/main.rs` and pet_store example
- set `BRRTR_LOCAL` when running CI workflow

## Testing
- `cargo check --locked --offline` *(fails: no matching package named `may` found)*