### PR TITLE
Add parameters to generated requests

### DIFF
--- a/examples/pet_store/src/handlers/get_item.rs
+++ b/examples/pet_store/src/handlers/get_item.rs
@@ -8,6 +8,7 @@ use crate::brrtrouter::typed::{ TypedHandlerRequest, TypedHandlerResponse, Typed
 
 #[derive(Debug, Deserialize)]
 pub struct Request {
+    pub id: String,
     }
 
 #[derive(Debug, Serialize)]

--- a/examples/pet_store/src/handlers/get_pet.rs
+++ b/examples/pet_store/src/handlers/get_pet.rs
@@ -8,6 +8,7 @@ use crate::brrtrouter::typed::{ TypedHandlerRequest, TypedHandlerResponse, Typed
 
 #[derive(Debug, Deserialize)]
 pub struct Request {
+    pub id: String,
     }
 
 #[derive(Debug, Serialize)]

--- a/examples/pet_store/src/handlers/get_post.rs
+++ b/examples/pet_store/src/handlers/get_post.rs
@@ -8,6 +8,8 @@ use crate::brrtrouter::typed::{ TypedHandlerRequest, TypedHandlerResponse, Typed
 
 #[derive(Debug, Deserialize)]
 pub struct Request {
+    pub user_id: String,
+    pub post_id: String,
     }
 
 #[derive(Debug, Serialize)]

--- a/examples/pet_store/src/handlers/get_user.rs
+++ b/examples/pet_store/src/handlers/get_user.rs
@@ -8,6 +8,7 @@ use crate::brrtrouter::typed::{ TypedHandlerRequest, TypedHandlerResponse, Typed
 
 #[derive(Debug, Deserialize)]
 pub struct Request {
+    pub user_id: String,
     }
 
 #[derive(Debug, Serialize)]

--- a/examples/pet_store/src/handlers/list_user_posts.rs
+++ b/examples/pet_store/src/handlers/list_user_posts.rs
@@ -9,6 +9,7 @@ use crate::brrtrouter::typed::{ TypedHandlerRequest, TypedHandlerResponse, Typed
 use crate::handlers::types::Post;
 #[derive(Debug, Deserialize)]
 pub struct Request {
+    pub user_id: String,
     }
 
 #[derive(Debug, Serialize)]

--- a/examples/pet_store/src/handlers/post_item.rs
+++ b/examples/pet_store/src/handlers/post_item.rs
@@ -10,7 +10,9 @@ use crate::brrtrouter::typed::{ TypedHandlerRequest, TypedHandlerResponse, Typed
 pub struct Request {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    
+
+    pub id: String,
+
     }
 
 #[derive(Debug, Serialize)]

--- a/templates/handler.rs.txt
+++ b/templates/handler.rs.txt
@@ -12,6 +12,7 @@ use crate::handlers::types::{{ import }};
 
 #[derive(Debug, Deserialize)]
 pub struct Request {
+    // Parameters and body fields
     {% for field in request_fields -%}
     {% if field.optional %}#[serde(skip_serializing_if = "Option::is_none")]
     pub {{ field.name }}: Option<{{ field.ty }}>,


### PR DESCRIPTION
## Summary
- generate request structs with path/query params merged with body fields
- add helper to convert parameters into `FieldDef`
- refresh pet_store example handlers to use the new request layout
- update handler template with comment for parameter fields

## Testing
- `cargo test -- --nocapture` *(fails: could not fetch crates)*