### PR TITLE
Implement typed request conversions

### DIFF
--- a/examples/pet_store/src/handlers/add_pet.rs
+++ b/examples/pet_store/src/handlers/add_pet.rs
@@ -26,25 +26,3 @@ pub fn handler(req: TypedHandlerRequest<Request>) -> Response {
     crate::controllers::add_pet::handle(req)
 }
 
-impl TypedHandlerFor<Request> for Request {
-    fn from_handler(req: HandlerRequest) -> TypedHandlerRequest<Self> {
-        // fill from req.body, req.path_params, etc
-        unimplemented!()
-    }
-
-    fn into_handler(self) -> HandlerRequest {
-        unimplemented!()
-    }
-}
-
-/// Custom trait to convert from typed request back to HandlerRequest
-pub trait FromTypedRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self;
-}
-
-impl FromTypedRequest for HandlerRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self {
-        // TODO: convert TypedHandlerRequest<Request> to HandlerRequest
-        unimplemented!()
-    }
-}

--- a/examples/pet_store/src/handlers/admin_settings.rs
+++ b/examples/pet_store/src/handlers/admin_settings.rs
@@ -21,25 +21,3 @@ pub fn handler(req: TypedHandlerRequest<Request>) -> Response {
     crate::controllers::admin_settings::handle(req)
 }
 
-impl TypedHandlerFor<Request> for Request {
-    fn from_handler(req: HandlerRequest) -> TypedHandlerRequest<Self> {
-        // fill from req.body, req.path_params, etc
-        unimplemented!()
-    }
-
-    fn into_handler(self) -> HandlerRequest {
-        unimplemented!()
-    }
-}
-
-/// Custom trait to convert from typed request back to HandlerRequest
-pub trait FromTypedRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self;
-}
-
-impl FromTypedRequest for HandlerRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self {
-        // TODO: convert TypedHandlerRequest<Request> to HandlerRequest
-        unimplemented!()
-    }
-}

--- a/examples/pet_store/src/handlers/get_item.rs
+++ b/examples/pet_store/src/handlers/get_item.rs
@@ -25,25 +25,3 @@ pub fn handler(req: TypedHandlerRequest<Request>) -> Response {
     crate::controllers::get_item::handle(req)
 }
 
-impl TypedHandlerFor<Request> for Request {
-    fn from_handler(req: HandlerRequest) -> TypedHandlerRequest<Self> {
-        // fill from req.body, req.path_params, etc
-        unimplemented!()
-    }
-
-    fn into_handler(self) -> HandlerRequest {
-        unimplemented!()
-    }
-}
-
-/// Custom trait to convert from typed request back to HandlerRequest
-pub trait FromTypedRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self;
-}
-
-impl FromTypedRequest for HandlerRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self {
-        // TODO: convert TypedHandlerRequest<Request> to HandlerRequest
-        unimplemented!()
-    }
-}

--- a/examples/pet_store/src/handlers/get_pet.rs
+++ b/examples/pet_store/src/handlers/get_pet.rs
@@ -30,26 +30,3 @@ pub struct Response {
 pub fn handler(req: TypedHandlerRequest<Request>) -> Response {
     crate::controllers::get_pet::handle(req)
 }
-
-impl TypedHandlerFor<Request> for Request {
-    fn from_handler(req: HandlerRequest) -> TypedHandlerRequest<Self> {
-        // fill from req.body, req.path_params, etc
-        unimplemented!()
-    }
-
-    fn into_handler(self) -> HandlerRequest {
-        unimplemented!()
-    }
-}
-
-/// Custom trait to convert from typed request back to HandlerRequest
-pub trait FromTypedRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self;
-}
-
-impl FromTypedRequest for HandlerRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self {
-        // TODO: convert TypedHandlerRequest<Request> to HandlerRequest
-        unimplemented!()
-    }
-}

--- a/examples/pet_store/src/handlers/get_post.rs
+++ b/examples/pet_store/src/handlers/get_post.rs
@@ -28,26 +28,3 @@ pub struct Response {
 pub fn handler(req: TypedHandlerRequest<Request>) -> Response {
     crate::controllers::get_post::handle(req)
 }
-
-impl TypedHandlerFor<Request> for Request {
-    fn from_handler(req: HandlerRequest) -> TypedHandlerRequest<Self> {
-        // fill from req.body, req.path_params, etc
-        unimplemented!()
-    }
-
-    fn into_handler(self) -> HandlerRequest {
-        unimplemented!()
-    }
-}
-
-/// Custom trait to convert from typed request back to HandlerRequest
-pub trait FromTypedRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self;
-}
-
-impl FromTypedRequest for HandlerRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self {
-        // TODO: convert TypedHandlerRequest<Request> to HandlerRequest
-        unimplemented!()
-    }
-}

--- a/examples/pet_store/src/handlers/get_user.rs
+++ b/examples/pet_store/src/handlers/get_user.rs
@@ -25,25 +25,3 @@ pub fn handler(req: TypedHandlerRequest<Request>) -> Response {
     crate::controllers::get_user::handle(req)
 }
 
-impl TypedHandlerFor<Request> for Request {
-    fn from_handler(req: HandlerRequest) -> TypedHandlerRequest<Self> {
-        // fill from req.body, req.path_params, etc
-        unimplemented!()
-    }
-
-    fn into_handler(self) -> HandlerRequest {
-        unimplemented!()
-    }
-}
-
-/// Custom trait to convert from typed request back to HandlerRequest
-pub trait FromTypedRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self;
-}
-
-impl FromTypedRequest for HandlerRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self {
-        // TODO: convert TypedHandlerRequest<Request> to HandlerRequest
-        unimplemented!()
-    }
-}

--- a/examples/pet_store/src/handlers/list_pets.rs
+++ b/examples/pet_store/src/handlers/list_pets.rs
@@ -20,26 +20,3 @@ pub struct Response {
 pub fn handler(req: TypedHandlerRequest<Request>) -> Response {
     crate::controllers::list_pets::handle(req)
 }
-
-impl TypedHandlerFor<Request> for Request {
-    fn from_handler(req: HandlerRequest) -> TypedHandlerRequest<Self> {
-        // fill from req.body, req.path_params, etc
-        unimplemented!()
-    }
-
-    fn into_handler(self) -> HandlerRequest {
-        unimplemented!()
-    }
-}
-
-/// Custom trait to convert from typed request back to HandlerRequest
-pub trait FromTypedRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self;
-}
-
-impl FromTypedRequest for HandlerRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self {
-        // TODO: convert TypedHandlerRequest<Request> to HandlerRequest
-        unimplemented!()
-    }
-}

--- a/examples/pet_store/src/handlers/list_user_posts.rs
+++ b/examples/pet_store/src/handlers/list_user_posts.rs
@@ -21,26 +21,3 @@ pub struct Response {
 pub fn handler(req: TypedHandlerRequest<Request>) -> Response {
     crate::controllers::list_user_posts::handle(req)
 }
-
-impl TypedHandlerFor<Request> for Request {
-    fn from_handler(req: HandlerRequest) -> TypedHandlerRequest<Self> {
-        // fill from req.body, req.path_params, etc
-        unimplemented!()
-    }
-
-    fn into_handler(self) -> HandlerRequest {
-        unimplemented!()
-    }
-}
-
-/// Custom trait to convert from typed request back to HandlerRequest
-pub trait FromTypedRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self;
-}
-
-impl FromTypedRequest for HandlerRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self {
-        // TODO: convert TypedHandlerRequest<Request> to HandlerRequest
-        unimplemented!()
-    }
-}

--- a/examples/pet_store/src/handlers/list_users.rs
+++ b/examples/pet_store/src/handlers/list_users.rs
@@ -21,26 +21,3 @@ pub struct Response {
 pub fn handler(req: TypedHandlerRequest<Request>) -> Response {
     crate::controllers::list_users::handle(req)
 }
-
-impl TypedHandlerFor<Request> for Request {
-    fn from_handler(req: HandlerRequest) -> TypedHandlerRequest<Self> {
-        // fill from req.body, req.path_params, etc
-        unimplemented!()
-    }
-
-    fn into_handler(self) -> HandlerRequest {
-        unimplemented!()
-    }
-}
-
-/// Custom trait to convert from typed request back to HandlerRequest
-pub trait FromTypedRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self;
-}
-
-impl FromTypedRequest for HandlerRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self {
-        // TODO: convert TypedHandlerRequest<Request> to HandlerRequest
-        unimplemented!()
-    }
-}

--- a/examples/pet_store/src/handlers/post_item.rs
+++ b/examples/pet_store/src/handlers/post_item.rs
@@ -28,26 +28,3 @@ pub struct Response {
 pub fn handler(req: TypedHandlerRequest<Request>) -> Response {
     crate::controllers::post_item::handle(req)
 }
-
-impl TypedHandlerFor<Request> for Request {
-    fn from_handler(req: HandlerRequest) -> TypedHandlerRequest<Self> {
-        // fill from req.body, req.path_params, etc
-        unimplemented!()
-    }
-
-    fn into_handler(self) -> HandlerRequest {
-        unimplemented!()
-    }
-}
-
-/// Custom trait to convert from typed request back to HandlerRequest
-pub trait FromTypedRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self;
-}
-
-impl FromTypedRequest for HandlerRequest {
-    fn from_typed_request(typed_req: TypedHandlerRequest<Request>) -> Self {
-        // TODO: convert TypedHandlerRequest<Request> to HandlerRequest
-        unimplemented!()
-    }
-}

--- a/src/typed.rs
+++ b/src/typed.rs
@@ -4,6 +4,7 @@ use crate::dispatcher::{Dispatcher, HandlerRequest, HandlerResponse};
 use http::Method;
 use may::sync::mpsc;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use anyhow::Result;
 use std::collections::HashMap;
 
 /// Trait implemented by typed coroutine handlers.
@@ -23,7 +24,7 @@ where
 }
 
 pub trait TypedHandlerFor<T>: Sized {
-    fn from_handler(req: HandlerRequest) -> TypedHandlerRequest<T>;
+    fn from_handler(req: HandlerRequest) -> anyhow::Result<TypedHandlerRequest<T>>;
     fn into_handler(self) -> HandlerRequest;
 }
 
@@ -43,6 +44,61 @@ pub struct TypedHandlerResponse<T: Serialize> {
     pub body: T,
 }
 
+impl<T> TypedHandlerFor<T> for TypedHandlerRequest<T>
+where
+    T: DeserializeOwned + Serialize,
+{
+    fn from_handler(req: HandlerRequest) -> Result<TypedHandlerRequest<T>> {
+        use serde_json::{Map, Value};
+
+        let mut data_map = Map::new();
+
+        for (k, v) in &req.path_params {
+            data_map.insert(k.clone(), Value::String(v.clone()));
+        }
+        for (k, v) in &req.query_params {
+            data_map.insert(k.clone(), Value::String(v.clone()));
+        }
+
+        if let Some(body) = req.body.clone() {
+            match body {
+                Value::Object(map) => {
+                    for (k, v) in map {
+                        data_map.insert(k, v);
+                    }
+                }
+                other => {
+                    data_map.insert("body".to_string(), other);
+                }
+            }
+        }
+
+        let data: T = serde_json::from_value(Value::Object(data_map))?;
+
+        Ok(TypedHandlerRequest {
+            method: req.method,
+            path: req.path,
+            handler_name: req.handler_name,
+            path_params: req.path_params,
+            query_params: req.query_params,
+            data,
+        })
+    }
+
+    fn into_handler(self) -> HandlerRequest {
+        let (tx, _rx) = mpsc::channel();
+        HandlerRequest {
+            method: self.method,
+            path: self.path,
+            handler_name: self.handler_name,
+            path_params: self.path_params,
+            query_params: self.query_params,
+            body: serde_json::to_value(self.data).ok(),
+            reply_tx: tx,
+        }
+    }
+}
+
 impl Dispatcher {
     /// Register a typed handler that deserializes the body into `TReq` and responds with `TRes`.
     pub unsafe fn register_typed<TReq, TRes, H>(&mut self, name: &str, handler: H)
@@ -57,43 +113,22 @@ impl Dispatcher {
         may::coroutine::spawn(move || {
             let handler = handler;
             for req in rx.iter() {
-                let data: TReq = match req.body {
-                    Some(json) => match serde_json::from_value(json) {
-                        Ok(v) => v,
-                        Err(err) => {
-                            let _ = req.reply_tx.send(HandlerResponse {
-                                status: 400,
-                                body: serde_json::json!({
-                                    "error": "Invalid request body",
-                                    "message": err.to_string()
-                                }),
-                            });
-                            continue;
-                        }
-                    },
-                    None => {
-                        let _ = req.reply_tx.send(HandlerResponse {
+                let reply_tx = req.reply_tx.clone();
+
+                let typed_req = match TypedHandlerRequest::<TReq>::from_handler(req) {
+                    Ok(v) => v,
+                    Err(err) => {
+                        let _ = reply_tx.send(HandlerResponse {
                             status: 400,
-                            body: serde_json::json!({
-                                "error": "Missing request body"
-                            }),
+                            body: serde_json::json!({"error": "Invalid request data", "message": err.to_string()}),
                         });
                         continue;
                     }
                 };
 
-                let typed_req = TypedHandlerRequest {
-                    method: req.method,
-                    path: req.path,
-                    handler_name: req.handler_name,
-                    path_params: req.path_params,
-                    query_params: req.query_params,
-                    data,
-                };
-
                 let result = handler.handle(typed_req);
 
-                let _ = req.reply_tx.send(HandlerResponse {
+                let _ = reply_tx.send(HandlerResponse {
                     status: 200,
                     body: serde_json::to_value(result).unwrap_or_else(|_| {
                         serde_json::json!({


### PR DESCRIPTION
## Summary
- support parsing HandlerRequest into TypedHandlerRequest via new `TypedHandlerFor` trait
- convert TypedHandlerRequest back to HandlerRequest
- use these conversions inside `register_typed`
- remove unused autogenerated trait impls

## Testing
- `cargo test --locked` *(fails: failed to download index)*