### PR TITLE
Handle typed parameters with schema conversion

### DIFF
--- a/examples/pet_store/src/registry.rs
+++ b/examples/pet_store/src/registry.rs
@@ -1,7 +1,7 @@
 
 // Auto-generated handler registry
 
-use brrtrouter::dispatcher::Dispatcher;
+use brrtrouter::{dispatcher::Dispatcher, spec::ParameterMeta};
 use crate::controllers::*;
 use crate::handlers::*;
 
@@ -9,42 +9,55 @@ pub unsafe fn register_all(dispatcher: &mut Dispatcher) {
     dispatcher.register_typed(
         "admin_settings",
         crate::controllers::admin_settings::AdminSettingsController,
+        vec![],
     );
     dispatcher.register_typed(
         "get_item",
         crate::controllers::get_item::GetItemController,
+        vec![ParameterMeta { name: "id".to_string(), location: "Path".to_string(), required: true, schema: None }],
     );
     dispatcher.register_typed(
         "post_item",
         crate::controllers::post_item::PostItemController,
+        vec![ParameterMeta { name: "id".to_string(), location: "Path".to_string(), required: true, schema: None }],
     );
     dispatcher.register_typed(
         "list_pets",
         crate::controllers::list_pets::ListPetsController,
+        vec![],
     );
     dispatcher.register_typed(
         "add_pet",
         crate::controllers::add_pet::AddPetController,
+        vec![],
     );
     dispatcher.register_typed(
         "get_pet",
         crate::controllers::get_pet::GetPetController,
+        vec![ParameterMeta { name: "id".to_string(), location: "Path".to_string(), required: true, schema: None }],
     );
     dispatcher.register_typed(
         "list_users",
         crate::controllers::list_users::ListUsersController,
+        vec![],
     );
     dispatcher.register_typed(
         "get_user",
         crate::controllers::get_user::GetUserController,
+        vec![ParameterMeta { name: "user_id".to_string(), location: "Path".to_string(), required: true, schema: None }],
     );
     dispatcher.register_typed(
         "list_user_posts",
         crate::controllers::list_user_posts::ListUserPostsController,
+        vec![ParameterMeta { name: "user_id".to_string(), location: "Path".to_string(), required: true, schema: None }],
     );
     dispatcher.register_typed(
         "get_post",
         crate::controllers::get_post::GetPostController,
+        vec![
+            ParameterMeta { name: "user_id".to_string(), location: "Path".to_string(), required: true, schema: None },
+            ParameterMeta { name: "post_id".to_string(), location: "Path".to_string(), required: true, schema: None },
+        ],
     );
     
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -25,6 +25,7 @@ pub struct RegistryEntry {
     pub name: String,
     pub request_type: String,
     pub controller_struct: String,
+    pub parameters: Vec<ParameterMeta>,
 }
 
 #[derive(Debug, Clone)]
@@ -165,6 +166,7 @@ pub fn generate_project_from_spec(spec_path: &Path, force: bool) -> anyhow::Resu
             name: handler.clone(),
             request_type: format!("{}::Request", handler),
             controller_struct: controller_struct.clone(),
+            parameters: route.parameters.clone(),
         });
 
         if let Some(schema) = &route.request_schema {

--- a/src/typed.rs
+++ b/src/typed.rs
@@ -1,6 +1,7 @@
 // typed.rs
 #[allow(unused_imports)]
 use crate::dispatcher::{Dispatcher, HandlerRequest, HandlerResponse};
+use crate::spec::ParameterMeta;
 use http::Method;
 use may::sync::mpsc;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -24,7 +25,10 @@ where
 }
 
 pub trait TypedHandlerFor<T>: Sized {
-    fn from_handler(req: HandlerRequest) -> anyhow::Result<TypedHandlerRequest<T>>;
+    fn from_handler(
+        req: HandlerRequest,
+        params: &[ParameterMeta],
+    ) -> anyhow::Result<TypedHandlerRequest<T>>;
     fn into_handler(self) -> HandlerRequest;
 }
 
@@ -48,16 +52,49 @@ impl<T> TypedHandlerFor<T> for TypedHandlerRequest<T>
 where
     T: DeserializeOwned + Serialize,
 {
-    fn from_handler(req: HandlerRequest) -> Result<TypedHandlerRequest<T>> {
-        use serde_json::{Map, Value};
+    fn from_handler(
+        req: HandlerRequest,
+        params: &[ParameterMeta],
+    ) -> Result<TypedHandlerRequest<T>> {
+        use serde_json::{json, Map, Value};
+
+        fn convert(value: &str, schema: Option<&Value>) -> Value {
+            if let Some(ty) = schema.and_then(|s| s.get("type").and_then(|v| v.as_str())) {
+                match ty {
+                    "integer" => value
+                        .parse::<i64>()
+                        .map(Value::from)
+                        .unwrap_or_else(|_| Value::String(value.to_string())),
+                    "number" => value
+                        .parse::<f64>()
+                        .map(Value::from)
+                        .unwrap_or_else(|_| Value::String(value.to_string())),
+                    "boolean" => value
+                        .parse::<bool>()
+                        .map(Value::from)
+                        .unwrap_or_else(|_| Value::String(value.to_string())),
+                    _ => Value::String(value.to_string()),
+                }
+            } else {
+                Value::String(value.to_string())
+            }
+        }
 
         let mut data_map = Map::new();
 
         for (k, v) in &req.path_params {
-            data_map.insert(k.clone(), Value::String(v.clone()));
+            let schema = params
+                .iter()
+                .find(|p| p.location == "Path" && p.name == *k)
+                .and_then(|p| p.schema.as_ref());
+            data_map.insert(k.clone(), convert(v, schema));
         }
         for (k, v) in &req.query_params {
-            data_map.insert(k.clone(), Value::String(v.clone()));
+            let schema = params
+                .iter()
+                .find(|p| p.location == "Query" && p.name == *k)
+                .and_then(|p| p.schema.as_ref());
+            data_map.insert(k.clone(), convert(v, schema));
         }
 
         if let Some(body) = req.body.clone() {
@@ -101,7 +138,12 @@ where
 
 impl Dispatcher {
     /// Register a typed handler that deserializes the body into `TReq` and responds with `TRes`.
-    pub unsafe fn register_typed<TReq, TRes, H>(&mut self, name: &str, handler: H)
+    pub unsafe fn register_typed<TReq, TRes, H>(
+        &mut self,
+        name: &str,
+        handler: H,
+        params: Vec<ParameterMeta>,
+    )
     where
         TReq: DeserializeOwned + Serialize + Send + 'static,
         TRes: Serialize + Send + 'static,
@@ -109,13 +151,15 @@ impl Dispatcher {
     {
         let (tx, rx) = mpsc::channel::<HandlerRequest>();
         let name = name.to_string();
+        let params_clone = params.clone();
 
         may::coroutine::spawn(move || {
             let handler = handler;
+            let params = params_clone;
             for req in rx.iter() {
                 let reply_tx = req.reply_tx.clone();
 
-                let typed_req = match TypedHandlerRequest::<TReq>::from_handler(req) {
+                let typed_req = match TypedHandlerRequest::<TReq>::from_handler(req, &params) {
                     Ok(v) => v,
                     Err(err) => {
                         let _ = reply_tx.send(HandlerResponse {

--- a/templates/registry.rs.txt
+++ b/templates/registry.rs.txt
@@ -1,7 +1,7 @@
 {# templates/registry.rs.txt #}
 // Auto-generated handler registry
 
-use brrtrouter::dispatcher::Dispatcher;
+use brrtrouter::{dispatcher::Dispatcher, spec::ParameterMeta};
 use crate::controllers::*;
 use crate::handlers::*;
 
@@ -10,6 +10,22 @@ pub unsafe fn register_all(dispatcher: &mut Dispatcher) {
     dispatcher.register_typed(
         "{{ entry.name }}",
         crate::controllers::{{ entry.name }}::{{ entry.controller_struct }},
+        vec![
+            {% for p in entry.parameters -%}
+            ParameterMeta {
+                name: "{{ p.name }}".to_string(),
+                location: "{{ p.location }}".to_string(),
+                required: {{ p.required }},
+                schema: {
+                    {% if p.schema.is_some() %}
+                    Some(serde_json::json!({{ p.schema | json }}))
+                    {% else %}
+                    None
+                    {% endif %}
+                },
+            },
+            {% endfor %}
+        ],
     );
     {% endfor %}
 }

--- a/tests/typed_tests.rs
+++ b/tests/typed_tests.rs
@@ -1,0 +1,40 @@
+use brrtrouter::{dispatcher::{HandlerRequest, HandlerResponse}, typed::TypedHandlerRequest, spec::ParameterMeta};
+use http::Method;
+use may::sync::mpsc;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::HashMap;
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Req {
+    id: i32,
+    active: bool,
+}
+
+#[test]
+fn test_from_handler_non_string_params() {
+    let (tx, _rx) = mpsc::channel::<HandlerResponse>();
+    let mut path_params = HashMap::new();
+    path_params.insert("id".to_string(), "42".to_string());
+    let mut query_params = HashMap::new();
+    query_params.insert("active".to_string(), "true".to_string());
+
+    let req = HandlerRequest {
+        method: Method::GET,
+        path: "/items/42".to_string(),
+        handler_name: "test".to_string(),
+        path_params: path_params.clone(),
+        query_params: query_params.clone(),
+        body: None,
+        reply_tx: tx,
+    };
+
+    let params = vec![
+        ParameterMeta { name: "id".to_string(), location: "Path".to_string(), required: true, schema: Some(json!({"type": "integer"})) },
+        ParameterMeta { name: "active".to_string(), location: "Query".to_string(), required: false, schema: Some(json!({"type": "boolean"})) },
+    ];
+
+    let typed = TypedHandlerRequest::<Req>::from_handler(req, &params).expect("conversion failed");
+    assert_eq!(typed.data.id, 42);
+    assert!(typed.data.active);
+}


### PR DESCRIPTION
## Summary
- convert path/query params based on `ParameterMeta` schema
- propagate route parameter metadata when registering typed handlers
- update generated registry and template to include parameter info
- test numeric and boolean parameter decoding

## Testing
- `cargo test --workspace --exclude pet_store --quiet` *(fails: failed to get `http` as a dependency of package `pet_store`)*