### PR TITLE
Fix typed helper generation

### DIFF
--- a/templates/controller.rs.txt
+++ b/templates/controller.rs.txt
@@ -19,3 +19,7 @@ impl Handler<Request, Response> for {{ struct_name }} {
         }
     }
 }
+
+pub fn handle(req: TypedHandlerRequest<Request>) -> Response {
+    {{ struct_name }}.handle(req)
+}

--- a/templates/handler.rs.txt
+++ b/templates/handler.rs.txt
@@ -8,7 +8,7 @@ use crate::brrtrouter::typed::TypedHandlerRequest;
 use crate::handlers::types::{{ import }};
 {% endfor -%}
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Request {
     // Parameters and body fields
     {% for field in request_fields -%}


### PR DESCRIPTION
## Summary
- update Askama templates for controllers and handlers
- revert direct edits to example sources

## Testing
- `cargo test --locked` *(fails: could not download crates)*