### PR TITLE
Fix string array example generation

### DIFF
--- a/examples/pet_store/src/controllers/get_pet.rs
+++ b/examples/pet_store/src/controllers/get_pet.rs
@@ -19,7 +19,7 @@ impl Handler<Request, Response> for GetPetController {
             
             name: "Max".to_string(),
             
-            tags: vec!["friendly".to_string().parse().unwrap(), "trained".to_string().parse().unwrap()],
+            tags: vec!["friendly".to_string(), "trained".to_string()],
             
             vaccinated: true,
             

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -433,10 +433,17 @@ fn rust_literal_for_example(field: &FieldDef, example: &Value) -> String {
         Value::Number(n) => n.to_string(),
         Value::Bool(b) => b.to_string(),
         Value::Array(items) => {
+            let is_vec_string = field.ty == "Vec<String>" || field.ty == "Vec<serde_json::Value>";
             let inner = items
                 .iter()
                 .map(|item| match item {
-                    Value::String(s) => format!("{:?}.to_string().parse().unwrap()", s),
+                    Value::String(s) => {
+                        if is_vec_string {
+                            format!("{:?}.to_string()", s)
+                        } else {
+                            format!("{:?}.to_string().parse().unwrap()", s)
+                        }
+                    }
                     Value::Number(n) => n.to_string(),
                     Value::Bool(b) => b.to_string(),
                     _ => "Default::default()".to_string(),


### PR DESCRIPTION
## Summary
- handle string vectors in `rust_literal_for_example`
- update `get_pet` controller example to compile without parsing

## Testing
- `cargo test --quiet` *(fails: failed to download dependency)*