### PR TITLE
Remove typed example structs

### DIFF
--- a/src/typed.rs
+++ b/src/typed.rs
@@ -169,22 +169,3 @@ impl Dispatcher {
     }
 }
 
-// Example: typed handler
-#[derive(Debug, Serialize, Deserialize)]
-pub struct CreatePetRequest {
-    pub name: String,
-}
-
-#[derive(Debug, Serialize)]
-pub struct CreatePetResponse {
-    pub id: String,
-    pub name: String,
-}
-
-pub fn create_pet_handler(req: TypedHandlerRequest<CreatePetRequest>) -> CreatePetResponse {
-    // Mock: assign static ID
-    CreatePetResponse {
-        id: "pet_1234".to_string(),
-        name: req.data.name,
-    }
-}


### PR DESCRIPTION
## Summary
- remove `CreatePetRequest`, `CreatePetResponse` and `create_pet_handler` example code from `src/typed.rs`

## Testing
- `cargo test` *(fails: could not connect to crates.io)*