### PR TITLE
Add build script for pet_store example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ curl "http://localhost:8080/items/123?debug=true" \
 }
 ```
 
+## 🏗 Building the Pet Store Example
+Run the provided script to build the example crate:
+
+```bash
+./scripts/build_pet_store.sh
+```
+
+You can pass additional cargo flags after the script name.
 
 ## 🧪 Running Tests
 

--- a/scripts/build_pet_store.sh
+++ b/scripts/build_pet_store.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+cargo build -p pet_store "$@"


### PR DESCRIPTION
## Summary
- add `scripts/build_pet_store.sh` helper
- document how to build the example in `README.md`

## Testing
- `cargo test -- --nocapture` *(fails: Could not connect to server)*