### PR TITLE
Add ParameterLocation enum

### DIFF
--- a/examples/pet_store/src/registry.rs
+++ b/examples/pet_store/src/registry.rs
@@ -1,6 +1,6 @@
 
 // Auto-generated handler registry
-use brrtrouter::{dispatcher::Dispatcher, spec::ParameterMeta};
+use brrtrouter::{dispatcher::Dispatcher, spec::{ParameterMeta, ParameterLocation}};
 use crate::controllers::*;
 use crate::handlers::*;
 
@@ -18,7 +18,7 @@ pub unsafe fn register_all(dispatcher: &mut Dispatcher) {
         vec![
             ParameterMeta {
                 name: "id".to_string(),
-                location: "Path".to_string(),
+                location: ParameterLocation::Path,
                 required: true,
                 schema: {
                     
@@ -35,7 +35,7 @@ pub unsafe fn register_all(dispatcher: &mut Dispatcher) {
         vec![
             ParameterMeta {
                 name: "id".to_string(),
-                location: "Path".to_string(),
+                location: ParameterLocation::Path,
                 required: true,
                 schema: {
                     
@@ -66,7 +66,7 @@ pub unsafe fn register_all(dispatcher: &mut Dispatcher) {
         vec![
             ParameterMeta {
                 name: "id".to_string(),
-                location: "Path".to_string(),
+                location: ParameterLocation::Path,
                 required: true,
                 schema: {
                     
@@ -90,7 +90,7 @@ pub unsafe fn register_all(dispatcher: &mut Dispatcher) {
         vec![
             ParameterMeta {
                 name: "user_id".to_string(),
-                location: "Path".to_string(),
+                location: ParameterLocation::Path,
                 required: true,
                 schema: {
                     
@@ -107,7 +107,7 @@ pub unsafe fn register_all(dispatcher: &mut Dispatcher) {
         vec![
             ParameterMeta {
                 name: "user_id".to_string(),
-                location: "Path".to_string(),
+                location: ParameterLocation::Path,
                 required: true,
                 schema: {
                     
@@ -124,7 +124,7 @@ pub unsafe fn register_all(dispatcher: &mut Dispatcher) {
         vec![
             ParameterMeta {
                 name: "user_id".to_string(),
-                location: "Path".to_string(),
+                location: ParameterLocation::Path,
                 required: true,
                 schema: {
                     
@@ -134,7 +134,7 @@ pub unsafe fn register_all(dispatcher: &mut Dispatcher) {
             },
             ParameterMeta {
                 name: "post_id".to_string(),
-                location: "Path".to_string(),
+                location: ParameterLocation::Path,
                 required: true,
                 schema: {
                     

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,4 +12,4 @@ pub mod spec;
 pub mod typed;
 mod validator;
 
-pub use spec::{load_spec, load_spec_from_spec, ParameterMeta, RouteMeta};
+pub use spec::{load_spec, load_spec_from_spec, ParameterMeta, ParameterLocation, RouteMeta};

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -5,6 +5,36 @@ use oas3::OpenApiV3Spec;
 use serde_json::Value;
 use std::path::PathBuf;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParameterLocation {
+    Path,
+    Query,
+    Header,
+    Cookie,
+}
+
+impl std::fmt::Display for ParameterLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParameterLocation::Path => write!(f, "Path"),
+            ParameterLocation::Query => write!(f, "Query"),
+            ParameterLocation::Header => write!(f, "Header"),
+            ParameterLocation::Cookie => write!(f, "Cookie"),
+        }
+    }
+}
+
+impl From<OasParameterLocation> for ParameterLocation {
+    fn from(loc: OasParameterLocation) -> Self {
+        match loc {
+            OasParameterLocation::Path => ParameterLocation::Path,
+            OasParameterLocation::Query => ParameterLocation::Query,
+            OasParameterLocation::Header => ParameterLocation::Header,
+            OasParameterLocation::Cookie => ParameterLocation::Cookie,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RouteMeta {
     pub method: Method,
@@ -22,7 +52,7 @@ pub struct RouteMeta {
 #[derive(Debug, Clone)]
 pub struct ParameterMeta {
     pub name: String,
-    pub location: String,
+    pub location: ParameterLocation,
     pub required: bool,
     pub schema: Option<Value>,
 }
@@ -203,7 +233,7 @@ fn extract_parameters(
 
             out.push(ParameterMeta {
                 name: param.name.clone(),
-                location: format!("{:?}", param.location),
+                location: ParameterLocation::from(param.location.clone()),
                 required: param.required.is_some(),
                 schema,
             });

--- a/src/typed.rs
+++ b/src/typed.rs
@@ -1,7 +1,7 @@
 // typed.rs
 #[allow(unused_imports)]
 use crate::dispatcher::{Dispatcher, HandlerRequest, HandlerResponse};
-use crate::spec::ParameterMeta;
+use crate::spec::{ParameterMeta, ParameterLocation};
 use http::Method;
 use may::sync::mpsc;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -79,14 +79,14 @@ where
         for (k, v) in &req.path_params {
             let schema = params
                 .iter()
-                .find(|p| p.location == "Path" && p.name == *k)
+                .find(|p| p.location == ParameterLocation::Path && p.name == *k)
                 .and_then(|p| p.schema.as_ref());
             data_map.insert(k.clone(), convert(v, schema));
         }
         for (k, v) in &req.query_params {
             let schema = params
                 .iter()
-                .find(|p| p.location == "Query" && p.name == *k)
+                .find(|p| p.location == ParameterLocation::Query && p.name == *k)
                 .and_then(|p| p.schema.as_ref());
             data_map.insert(k.clone(), convert(v, schema));
         }

--- a/templates/registry.rs.txt
+++ b/templates/registry.rs.txt
@@ -1,6 +1,6 @@
 {# templates/registry.rs.txt #}
 // Auto-generated handler registry
-use brrtrouter::{dispatcher::Dispatcher, spec::ParameterMeta};
+use brrtrouter::{dispatcher::Dispatcher, spec::{ParameterMeta, ParameterLocation}};
 use crate::controllers::*;
 use crate::handlers::*;
 
@@ -13,7 +13,7 @@ pub unsafe fn register_all(dispatcher: &mut Dispatcher) {
             {% for p in entry.parameters -%}
             ParameterMeta {
                 name: "{{ p.name }}".to_string(),
-                location: "{{ p.location }}".to_string(),
+                location: ParameterLocation::{{ p.location }},
                 required: {{ p.required }},
                 schema: {
                     {% if p.schema.is_some() %}

--- a/tests/dispatcher_tests.rs
+++ b/tests/dispatcher_tests.rs
@@ -1,4 +1,4 @@
-use brrtrouter::{load_spec, router::{Router, RouteMatch}, dispatcher::{Dispatcher, HandlerRequest}, typed::{Handler, TypedHandlerRequest}, spec::ParameterMeta};
+use brrtrouter::{load_spec, router::{Router, RouteMatch}, dispatcher::{Dispatcher, HandlerRequest}, typed::{Handler, TypedHandlerRequest}, spec::{ParameterMeta, ParameterLocation}};
 use http::Method;
 use may::sync::mpsc;
 use serde_json::json;
@@ -112,13 +112,13 @@ fn test_typed_controller_params() {
             vec![
                 ParameterMeta {
                     name: "id".to_string(),
-                    location: "Path".to_string(),
+                    location: ParameterLocation::Path,
                     required: true,
                     schema: Some(json!({"type": "integer"})),
                 },
                 ParameterMeta {
                     name: "debug".to_string(),
-                    location: "Query".to_string(),
+                    location: ParameterLocation::Query,
                     required: false,
                     schema: Some(json!({"type": "boolean"})),
                 },

--- a/tests/typed_tests.rs
+++ b/tests/typed_tests.rs
@@ -1,4 +1,4 @@
-use brrtrouter::{dispatcher::{HandlerRequest, HandlerResponse}, typed::TypedHandlerRequest, spec::ParameterMeta};
+use brrtrouter::{dispatcher::{HandlerRequest, HandlerResponse}, typed::TypedHandlerRequest, spec::{ParameterMeta, ParameterLocation}};
 use http::Method;
 use may::sync::mpsc;
 use serde::{Deserialize, Serialize};
@@ -31,8 +31,8 @@ fn test_from_handler_non_string_params() {
     };
 
     let params = vec![
-        ParameterMeta { name: "id".to_string(), location: "Path".to_string(), required: true, schema: Some(json!({"type": "integer"})) },
-        ParameterMeta { name: "active".to_string(), location: "Query".to_string(), required: false, schema: Some(json!({"type": "boolean"})) },
+        ParameterMeta { name: "id".to_string(), location: ParameterLocation::Path, required: true, schema: Some(json!({"type": "integer"})) },
+        ParameterMeta { name: "active".to_string(), location: ParameterLocation::Query, required: false, schema: Some(json!({"type": "boolean"})) },
     ];
 
     let typed = TypedHandlerRequest::<Req>::from_handler(req, &params).expect("conversion failed");


### PR DESCRIPTION
## Summary
- introduce `ParameterLocation` enum in spec
- update registry template and typed handler conversion
- adjust generated example registry
- re-export `ParameterLocation` from `lib`
- update tests for enum-based parameter location

## Testing
- `cargo test` *(fails: failed to download crates)*