### PR TITLE
Improve controller examples and imports

### DIFF
--- a/examples/pet_store/src/controllers/add_pet.rs
+++ b/examples/pet_store/src/controllers/add_pet.rs
@@ -3,12 +3,16 @@
 use crate::brrtrouter::typed::{TypedHandlerRequest, Handler};
 use crate::handlers::add_pet::{ Request, Response };
 
+
 pub struct AddPetController;
 
 impl Handler<Request, Response> for AddPetController {
     fn handle(&self, _req: TypedHandlerRequest<Request>) -> Response {
         // Example response:
-        // 
+        // {
+        //   "id": 67890,
+        //   "status": "success"
+        // }
         Response {
             
             id: Some(67890),

--- a/examples/pet_store/src/controllers/admin_settings.rs
+++ b/examples/pet_store/src/controllers/admin_settings.rs
@@ -3,15 +3,21 @@
 use crate::brrtrouter::typed::{TypedHandlerRequest, Handler};
 use crate::handlers::admin_settings::{ Request, Response };
 
+
 pub struct AdminSettingsController;
 
 impl Handler<Request, Response> for AdminSettingsController {
     fn handle(&self, _req: TypedHandlerRequest<Request>) -> Response {
         // Example response:
-        // 
+        // {
+        //   "feature_flags": {
+        //     "analytics": false,
+        //     "beta": true
+        //   }
+        // }
         Response {
             
-            feature_flags: Some(Default::default()),
+            feature_flags: Some(serde_json::json!({"analytics":false,"beta":true})),
             
         }
     }

--- a/examples/pet_store/src/controllers/get_item.rs
+++ b/examples/pet_store/src/controllers/get_item.rs
@@ -3,12 +3,16 @@
 use crate::brrtrouter::typed::{TypedHandlerRequest, Handler};
 use crate::handlers::get_item::{ Request, Response };
 
+
 pub struct GetItemController;
 
 impl Handler<Request, Response> for GetItemController {
     fn handle(&self, _req: TypedHandlerRequest<Request>) -> Response {
         // Example response:
-        // 
+        // {
+        //   "id": "item-001",
+        //   "name": "Sample Item"
+        // }
         Response {
             
             id: Some("item-001".to_string()),

--- a/examples/pet_store/src/controllers/get_pet.rs
+++ b/examples/pet_store/src/controllers/get_pet.rs
@@ -3,12 +3,23 @@
 use crate::brrtrouter::typed::{TypedHandlerRequest, Handler};
 use crate::handlers::get_pet::{ Request, Response };
 
+
 pub struct GetPetController;
 
 impl Handler<Request, Response> for GetPetController {
     fn handle(&self, _req: TypedHandlerRequest<Request>) -> Response {
         // Example response:
-        // 
+        // {
+        //   "age": 3,
+        //   "breed": "Golden Retriever",
+        //   "id": 12345,
+        //   "name": "Max",
+        //   "tags": [
+        //     "friendly",
+        //     "trained"
+        //   ],
+        //   "vaccinated": true
+        // }
         Response {
             
             age: 3,

--- a/examples/pet_store/src/controllers/get_post.rs
+++ b/examples/pet_store/src/controllers/get_post.rs
@@ -3,12 +3,17 @@
 use crate::brrtrouter::typed::{TypedHandlerRequest, Handler};
 use crate::handlers::get_post::{ Request, Response };
 
+
 pub struct GetPostController;
 
 impl Handler<Request, Response> for GetPostController {
     fn handle(&self, _req: TypedHandlerRequest<Request>) -> Response {
         // Example response:
-        // 
+        // {
+        //   "body": "Welcome to the blog",
+        //   "id": "post1",
+        //   "title": "Intro"
+        // }
         Response {
             
             body: Some("Welcome to the blog".to_string()),

--- a/examples/pet_store/src/controllers/get_user.rs
+++ b/examples/pet_store/src/controllers/get_user.rs
@@ -3,12 +3,16 @@
 use crate::brrtrouter::typed::{TypedHandlerRequest, Handler};
 use crate::handlers::get_user::{ Request, Response };
 
+
 pub struct GetUserController;
 
 impl Handler<Request, Response> for GetUserController {
     fn handle(&self, _req: TypedHandlerRequest<Request>) -> Response {
         // Example response:
-        // 
+        // {
+        //   "id": "abc-123",
+        //   "name": "John"
+        // }
         Response {
             
             id: Some("abc-123".to_string()),

--- a/examples/pet_store/src/controllers/list_pets.rs
+++ b/examples/pet_store/src/controllers/list_pets.rs
@@ -2,13 +2,38 @@
 // User-owned controller for handler 'list_pets'.
 use crate::brrtrouter::typed::{TypedHandlerRequest, Handler};
 use crate::handlers::list_pets::{ Request, Response };
+use crate::handlers::types::Pet;
+
 
 pub struct ListPetsController;
 
 impl Handler<Request, Response> for ListPetsController {
     fn handle(&self, _req: TypedHandlerRequest<Request>) -> Response {
         // Example response:
-        // 
+        // [
+        //   {
+        //     "age": 3,
+        //     "breed": "Golden Retriever",
+        //     "id": 12345,
+        //     "name": "Max",
+        //     "tags": [
+        //       "friendly",
+        //       "trained"
+        //     ],
+        //     "vaccinated": true
+        //   },
+        //   {
+        //     "age": 2,
+        //     "breed": "Labrador",
+        //     "id": 67890,
+        //     "name": "Bella",
+        //     "tags": [
+        //       "puppy",
+        //       "playful"
+        //     ],
+        //     "vaccinated": true
+        //   }
+        // ]
         Response {
             
             items: vec![Default::default()],

--- a/examples/pet_store/src/controllers/list_user_posts.rs
+++ b/examples/pet_store/src/controllers/list_user_posts.rs
@@ -2,13 +2,26 @@
 // User-owned controller for handler 'list_user_posts'.
 use crate::brrtrouter::typed::{TypedHandlerRequest, Handler};
 use crate::handlers::list_user_posts::{ Request, Response };
+use crate::handlers::types::Post;
+
 
 pub struct ListUserPostsController;
 
 impl Handler<Request, Response> for ListUserPostsController {
     fn handle(&self, _req: TypedHandlerRequest<Request>) -> Response {
         // Example response:
-        // 
+        // [
+        //   {
+        //     "body": "Welcome to the blog",
+        //     "id": "post1",
+        //     "title": "Intro"
+        //   },
+        //   {
+        //     "body": "Thanks for reading",
+        //     "id": "post2",
+        //     "title": "Follow-up"
+        //   }
+        // ]
         Response {
             
             items: vec![Default::default()],

--- a/examples/pet_store/src/controllers/list_users.rs
+++ b/examples/pet_store/src/controllers/list_users.rs
@@ -2,16 +2,29 @@
 // User-owned controller for handler 'list_users'.
 use crate::brrtrouter::typed::{TypedHandlerRequest, Handler};
 use crate::handlers::list_users::{ Request, Response };
+use crate::handlers::types::User;
+
 
 pub struct ListUsersController;
 
 impl Handler<Request, Response> for ListUsersController {
     fn handle(&self, _req: TypedHandlerRequest<Request>) -> Response {
         // Example response:
-        // 
+        // {
+        //   "users": [
+        //     {
+        //       "id": "abc-123",
+        //       "name": "John"
+        //     },
+        //     {
+        //       "id": "def-456",
+        //       "name": "Jane"
+        //     }
+        //   ]
+        // }
         Response {
             
-            users: Some(vec![Default::default(), Default::default()]),
+            users: Some(vec![serde_json::from_value::<User>(serde_json::json!({"id":"abc-123","name":"John"})).unwrap(), serde_json::from_value::<User>(serde_json::json!({"id":"def-456","name":"Jane"})).unwrap()]),
             
         }
     }

--- a/examples/pet_store/src/controllers/post_item.rs
+++ b/examples/pet_store/src/controllers/post_item.rs
@@ -3,12 +3,16 @@
 use crate::brrtrouter::typed::{TypedHandlerRequest, Handler};
 use crate::handlers::post_item::{ Request, Response };
 
+
 pub struct PostItemController;
 
 impl Handler<Request, Response> for PostItemController {
     fn handle(&self, _req: TypedHandlerRequest<Request>) -> Response {
         // Example response:
-        // 
+        // {
+        //   "id": "item-001",
+        //   "name": "New Item"
+        // }
         Response {
             
             id: Some("item-001".to_string()),

--- a/examples/pet_store/src/handlers/types.rs
+++ b/examples/pet_store/src/handlers/types.rs
@@ -3,6 +3,106 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Post {
+    pub body: String,
+    pub id: String,
+    pub title: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct ListUsersResponse {
+    pub users: Vec<User>,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct AdminSettings {
+    pub feature_flags: serde_json::Value,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct CreatePetRequest {
+    pub name: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct User {
+    pub id: String,
+    pub name: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct ListPetsResponse {
+    pub items: Vec<Pet>,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct GetPetResponse {
+    pub age: i32,
+    pub breed: String,
+    pub id: i32,
+    pub name: String,
+    pub tags: Vec<String>,
+    pub vaccinated: bool,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct PostItemRequest {
+    pub name: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct GetItemResponse {
+    pub id: String,
+    pub name: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct CreateItemRequest {
+    pub name: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct UserList {
+    pub users: Vec<User>,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct PostItemResponse {
+    pub id: String,
+    pub name: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct AddPetResponse {
+    pub id: i32,
+    pub status: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct GetUserResponse {
+    pub id: String,
+    pub name: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct PetCreationResponse {
+    pub id: i32,
+    pub status: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct GetPostResponse {
+    pub body: String,
+    pub id: String,
+    pub title: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct AdminSettingsResponse {
+    pub feature_flags: serde_json::Value,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct ListUserPostsResponse {
     pub items: Vec<Post>,
     }
@@ -18,112 +118,12 @@ pub struct Pet {
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct PostItemRequest {
-    pub name: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct PetCreationResponse {
-    pub id: i32,
-    pub status: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct User {
-    pub id: String,
-    pub name: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct Post {
-    pub body: String,
-    pub id: String,
-    pub title: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct UserList {
-    pub users: Vec<User>,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct AddPetResponse {
-    pub id: i32,
-    pub status: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct GetPetResponse {
-    pub age: i32,
-    pub breed: String,
-    pub id: i32,
-    pub name: String,
-    pub tags: Vec<String>,
-    pub vaccinated: bool,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct GetUserResponse {
-    pub id: String,
+pub struct AddPetRequest {
     pub name: String,
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Item {
     pub id: String,
-    pub name: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct PostItemResponse {
-    pub id: String,
-    pub name: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct AddPetRequest {
-    pub name: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct ListPetsResponse {
-    pub items: Vec<Pet>,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct AdminSettings {
-    pub feature_flags: serde_json::Value,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct AdminSettingsResponse {
-    pub feature_flags: serde_json::Value,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct GetItemResponse {
-    pub id: String,
-    pub name: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct ListUsersResponse {
-    pub users: Vec<User>,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct CreatePetRequest {
-    pub name: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct GetPostResponse {
-    pub body: String,
-    pub id: String,
-    pub title: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct CreateItemRequest {
     pub name: String,
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,4 @@ pub mod spec;
 pub mod typed;
 mod validator;
 
-pub use spec::{load_spec, load_spec_from_spec, ParameterMeta, ParameterLocation, RouteMeta};
+pub use spec::{load_spec, load_spec_from_spec, ParameterLocation, ParameterMeta, RouteMeta};

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,9 +25,7 @@ fn main() -> io::Result<()> {
     } else {
         "0.0.0.0:8080"
     };
-    let server = HttpServer(service)
-        .start(addr)
-        .map_err(io::Error::other)?;
+    let server = HttpServer(service).start(addr).map_err(io::Error::other)?;
     println!("Server started successfully on {addr}");
     server
         .join()

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1,6 +1,8 @@
 use crate::validator::{fail_if_issues, ValidationIssue};
 use http::Method;
-use oas3::spec::{MediaTypeExamples, ObjectOrReference, Parameter, ParameterIn as OasParameterLocation};
+use oas3::spec::{
+    MediaTypeExamples, ObjectOrReference, Parameter, ParameterIn as OasParameterLocation,
+};
 use oas3::OpenApiV3Spec;
 use serde_json::Value;
 use std::path::PathBuf;
@@ -57,7 +59,7 @@ pub struct ParameterMeta {
     pub schema: Option<Value>,
 }
 
-pub fn load_spec(file_path: &str, ) -> anyhow::Result<(Vec<RouteMeta>, String)> {
+pub fn load_spec(file_path: &str) -> anyhow::Result<(Vec<RouteMeta>, String)> {
     let content = std::fs::read_to_string(file_path)?;
     let spec: OpenApiV3Spec = if file_path.ends_with(".yaml") || file_path.ends_with(".yml") {
         serde_yaml::from_str(&content)?
@@ -78,7 +80,7 @@ pub fn load_spec(file_path: &str, ) -> anyhow::Result<(Vec<RouteMeta>, String)> 
 }
 
 /// Build route metadata from an already parsed [`OpenApiV3Spec`].
-pub fn load_spec_from_spec(spec: OpenApiV3Spec, ) -> anyhow::Result<Vec<RouteMeta>> {
+pub fn load_spec_from_spec(spec: OpenApiV3Spec) -> anyhow::Result<Vec<RouteMeta>> {
     let slug = spec
         .info
         .title
@@ -217,18 +219,16 @@ fn extract_parameters(
 ) -> Vec<ParameterMeta> {
     let mut out = Vec::new();
     for p in params {
-            let param = match p {
-                ObjectOrReference::Object(obj) => Some(obj),
-                ObjectOrReference::Ref { ref_path } => resolve_parameter_ref(spec, &ref_path),
-            };
+        let param = match p {
+            ObjectOrReference::Object(obj) => Some(obj),
+            ObjectOrReference::Ref { ref_path } => resolve_parameter_ref(spec, &ref_path),
+        };
 
         if let Some(param) = param {
             let schema = param.schema.as_ref().and_then(|s| match s {
                 ObjectOrReference::Object(obj) => serde_json::to_value(obj).ok(),
-                ObjectOrReference::Ref { ref_path } => {
-                    resolve_schema_ref(spec, ref_path)
-                        .and_then(|sch| serde_json::to_value(sch).ok())
-                }
+                ObjectOrReference::Ref { ref_path } => resolve_schema_ref(spec, ref_path)
+                    .and_then(|sch| serde_json::to_value(sch).ok()),
             });
 
             out.push(ParameterMeta {
@@ -242,10 +242,7 @@ fn extract_parameters(
     out
 }
 
-pub fn build_routes(
-    spec: &OpenApiV3Spec,
-    slug: &str,
-) -> anyhow::Result<Vec<RouteMeta>> {
+pub fn build_routes(spec: &OpenApiV3Spec, slug: &str) -> anyhow::Result<Vec<RouteMeta>> {
     let mut routes = Vec::new();
     let mut issues = Vec::new();
 

--- a/src/typed.rs
+++ b/src/typed.rs
@@ -1,11 +1,11 @@
 // typed.rs
 #[allow(unused_imports)]
 use crate::dispatcher::{Dispatcher, HandlerRequest, HandlerResponse};
-use crate::spec::{ParameterMeta, ParameterLocation};
+use crate::spec::{ParameterLocation, ParameterMeta};
+use anyhow::Result;
 use http::Method;
 use may::sync::mpsc;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use anyhow::Result;
 use std::collections::HashMap;
 
 /// Trait implemented by typed coroutine handlers.
@@ -40,7 +40,6 @@ pub struct TypedHandlerRequest<T> {
     pub query_params: HashMap<String, String>,
     pub data: T,
 }
-
 
 impl<T> TypedHandlerFor<T> for TypedHandlerRequest<T>
 where
@@ -115,7 +114,6 @@ where
             data,
         })
     }
-
 }
 
 impl Dispatcher {
@@ -125,8 +123,7 @@ impl Dispatcher {
         name: &str,
         handler: H,
         params: Vec<ParameterMeta>,
-    )
-    where
+    ) where
         TReq: DeserializeOwned + Serialize + Send + 'static,
         TRes: Serialize + Send + 'static,
         H: Handler<TReq, TRes> + Send + 'static,

--- a/templates/controller.rs.txt
+++ b/templates/controller.rs.txt
@@ -2,6 +2,9 @@
 // User-owned controller for handler '{{ handler_name }}'.
 use crate::brrtrouter::typed::{TypedHandlerRequest, Handler};
 use crate::handlers::{{ handler_name }}::{ Request, Response };
+{% for import in imports -%}
+use crate::handlers::types::{{ import }};
+{% endfor %}
 
 pub struct {{ struct_name }};
 
@@ -9,7 +12,7 @@ impl Handler<Request, Response> for {{ struct_name }} {
     fn handle(&self, _req: TypedHandlerRequest<Request>) -> Response {
         {% if has_example -%}
         // Example response:
-        // {{ example_json | indent(8) }}
+{{ example_json }}
         {%- endif %}
         Response {
             {% for field in response_fields %}

--- a/tests/typed_tests.rs
+++ b/tests/typed_tests.rs
@@ -1,10 +1,14 @@
-use brrtrouter::{dispatcher::{HandlerRequest, HandlerResponse}, typed::TypedHandlerRequest, spec::{ParameterMeta, ParameterLocation}};
+use brrtrouter::typed::TypedHandlerFor;
+use brrtrouter::{
+    dispatcher::{HandlerRequest, HandlerResponse},
+    spec::{ParameterLocation, ParameterMeta},
+    typed::TypedHandlerRequest,
+};
 use http::Method;
 use may::sync::mpsc;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::HashMap;
-use brrtrouter::typed::TypedHandlerFor;
 
 #[derive(Debug, Deserialize, Serialize)]
 struct Req {
@@ -31,8 +35,18 @@ fn test_from_handler_non_string_params() {
     };
 
     let params = vec![
-        ParameterMeta { name: "id".to_string(), location: ParameterLocation::Path, required: true, schema: Some(json!({"type": "integer"})) },
-        ParameterMeta { name: "active".to_string(), location: ParameterLocation::Query, required: false, schema: Some(json!({"type": "boolean"})) },
+        ParameterMeta {
+            name: "id".to_string(),
+            location: ParameterLocation::Path,
+            required: true,
+            schema: Some(json!({"type": "integer"})),
+        },
+        ParameterMeta {
+            name: "active".to_string(),
+            location: ParameterLocation::Query,
+            required: false,
+            schema: Some(json!({"type": "boolean"})),
+        },
     ];
 
     let typed = TypedHandlerRequest::<Req>::from_handler(req, &params).expect("conversion failed");


### PR DESCRIPTION
## Summary
- fix controller template to comment example JSON properly
- generate imports for controller example types
- regenerate pet store example controllers

## Testing
- `cargo test`
- `cargo run --bin brrtrouter-gen -- generate --spec examples/openapi.yaml --force`
