### PR TITLE
Ensure deterministic ordering for generated types

### DIFF
--- a/examples/pet_store/src/handlers/types.rs
+++ b/examples/pet_store/src/handlers/types.rs
@@ -3,15 +3,14 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct Post {
-    pub body: String,
-    pub id: String,
-    pub title: String,
+pub struct AddPetRequest {
+    pub name: String,
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct ListUsersResponse {
-    pub users: Vec<User>,
+pub struct AddPetResponse {
+    pub id: i32,
+    pub status: String,
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -20,19 +19,24 @@ pub struct AdminSettings {
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
+pub struct AdminSettingsResponse {
+    pub feature_flags: serde_json::Value,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct CreateItemRequest {
+    pub name: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct CreatePetRequest {
     pub name: String,
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct User {
+pub struct GetItemResponse {
     pub id: String,
     pub name: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct ListPetsResponse {
-    pub items: Vec<Pet>,
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -46,36 +50,10 @@ pub struct GetPetResponse {
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct PostItemRequest {
-    pub name: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct GetItemResponse {
+pub struct GetPostResponse {
+    pub body: String,
     pub id: String,
-    pub name: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct CreateItemRequest {
-    pub name: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct UserList {
-    pub users: Vec<User>,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct PostItemResponse {
-    pub id: String,
-    pub name: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct AddPetResponse {
-    pub id: i32,
-    pub status: String,
+    pub title: String,
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -85,26 +63,24 @@ pub struct GetUserResponse {
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct PetCreationResponse {
-    pub id: i32,
-    pub status: String,
-    }
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct GetPostResponse {
-    pub body: String,
+pub struct Item {
     pub id: String,
-    pub title: String,
+    pub name: String,
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct AdminSettingsResponse {
-    pub feature_flags: serde_json::Value,
+pub struct ListPetsResponse {
+    pub items: Vec<Pet>,
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct ListUserPostsResponse {
     pub items: Vec<Post>,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct ListUsersResponse {
+    pub users: Vec<User>,
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -118,12 +94,36 @@ pub struct Pet {
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct AddPetRequest {
+pub struct PetCreationResponse {
+    pub id: i32,
+    pub status: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Post {
+    pub body: String,
+    pub id: String,
+    pub title: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct PostItemRequest {
     pub name: String,
     }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct Item {
+pub struct PostItemResponse {
     pub id: String,
     pub name: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct User {
+    pub id: String,
+    pub name: String,
+    }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct UserList {
+    pub users: Vec<User>,
     }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -2,7 +2,7 @@ use crate::dummy_value;
 use crate::spec::{load_spec, resolve_schema_ref, ParameterMeta, RouteMeta};
 use askama::Template;
 use serde_json::Value;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 
@@ -63,7 +63,7 @@ pub struct RegistryTemplateData {
 #[derive(Template)]
 #[template(path = "handler_types.rs.txt")]
 pub struct TypesTemplateData {
-    pub types: HashMap<String, TypeDefinition>,
+    pub types: BTreeMap<String, TypeDefinition>,
 }
 
 #[derive(Template)]
@@ -320,10 +320,11 @@ fn write_registry_rs(dir: &Path, entries: &[RegistryEntry]) -> anyhow::Result<()
 
 fn write_types_rs(dir: &Path, types: &HashMap<String, TypeDefinition>) -> anyhow::Result<()> {
     let path = dir.join("types.rs");
-    let rendered = TypesTemplateData {
-        types: types.clone(),
+    let mut sorted = BTreeMap::new();
+    for (name, def) in types {
+        sorted.insert(name.clone(), def.clone());
     }
-    .render()?;
+    let rendered = TypesTemplateData { types: sorted }.render()?;
     fs::write(path.clone(), rendered)?;
     println!("✅ Generated types.rs → {:?}", path);
     Ok(())


### PR DESCRIPTION
## Summary
- use `BTreeMap` for `TypesTemplateData`
- sort type definitions in `write_types_rs`
- regenerate example types with new deterministic order

## Testing
- `cargo test`
- `cargo run --bin brrtrouter-gen -- generate --spec examples/openapi.yaml --force`