### PR TITLE
Add auto formatting to generator CLI

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,8 +27,12 @@ pub fn run_cli() -> Result<(), Box<dyn std::error::Error>> {
     match &cli.command {
         Commands::Generate { spec, force } => {
             let (_routes, _slug) = load_spec(spec.to_str().unwrap())?;
-            crate::generator::generate_project_from_spec(spec.as_path(), *force)
+            let project_dir = crate::generator::generate_project_from_spec(spec.as_path(), *force)
                 .expect("failed to generate example project");
+            // Format the newly generated project
+            if let Err(e) = crate::generator::format_project(&project_dir) {
+                eprintln!("cargo fmt failed: {e}");
+            }
             Ok(())
         }
     }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -87,7 +87,12 @@ pub struct ControllerTemplateData {
     pub imports: Vec<String>,
 }
 
-pub fn generate_project_from_spec(spec_path: &Path, force: bool) -> anyhow::Result<()> {
+use std::path::PathBuf;
+
+pub fn generate_project_from_spec(
+    spec_path: &Path,
+    force: bool,
+) -> anyhow::Result<PathBuf> {
     let (mut routes, slug) = load_spec(spec_path.to_str().unwrap())?;
     let base_dir = Path::new("examples").join(&slug);
     let src_dir = base_dir.join("src");
@@ -191,6 +196,16 @@ pub fn generate_project_from_spec(spec_path: &Path, force: bool) -> anyhow::Resu
     )?;
     write_mod_rs(&controller_dir, &modules_controllers, "controllers")?;
 
+    Ok(base_dir)
+}
+
+pub fn format_project(dir: &Path) -> anyhow::Result<()> {
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.arg("fmt").current_dir(dir);
+    let status = cmd.status()?;
+    if !status.success() {
+        anyhow::bail!("cargo fmt failed");
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- return project path from `generate_project_from_spec`
- format generated examples using `cargo fmt`
- wire formatting into CLI

## Testing
- `cargo test --quiet`