### PR TITLE
Add generator helper tests

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -398,7 +398,7 @@ fn collect_component_schemas(spec_path: &Path) -> anyhow::Result<HashMap<String,
     Ok(types)
 }
 
-fn to_camel_case(s: &str) -> String {
+pub fn to_camel_case(s: &str) -> String {
     s.split('_')
         .map(|w| {
             let mut chars = w.chars();
@@ -410,7 +410,7 @@ fn to_camel_case(s: &str) -> String {
         .collect()
 }
 
-fn is_named_type(ty: &str) -> bool {
+pub fn is_named_type(ty: &str) -> bool {
     let primitives = [
         "String",
         "i32",
@@ -468,7 +468,7 @@ mod tests {
     }
 }
 
-fn rust_literal_for_example(field: &FieldDef, example: &Value) -> String {
+pub fn rust_literal_for_example(field: &FieldDef, example: &Value) -> String {
     let literal = match example {
         Value::String(s) => format!("{:?}.to_string()", s),
         Value::Number(n) => n.to_string(),
@@ -628,7 +628,7 @@ pub fn extract_fields(schema: &Value) -> Vec<FieldDef> {
     fields
 }
 
-fn schema_to_type(schema: &Value) -> String {
+pub fn schema_to_type(schema: &Value) -> String {
     if let Some(r) = schema.get("$ref").and_then(|v| v.as_str()) {
         if let Some(name) = r.strip_prefix("#/components/schemas/") {
             return to_camel_case(name);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ pub mod cli;
 pub mod dispatcher;
 mod dummy_value;
 mod echo;
-mod generator;
+pub mod generator;
 pub mod router;
 pub mod server;
 pub mod spec;

--- a/tests/generator_tests.rs
+++ b/tests/generator_tests.rs
@@ -1,0 +1,94 @@
+use brrtrouter::generator::{
+    process_schema_type, extract_fields, parameter_to_field, rust_literal_for_example,
+    schema_to_type, to_camel_case, is_named_type, FieldDef, TypeDefinition
+};
+use brrtrouter::spec::{ParameterMeta, ParameterLocation};
+use serde_json::json;
+use std::collections::HashMap;
+
+#[test]
+fn test_to_camel_case() {
+    assert_eq!(to_camel_case("my_type"), "MyType");
+    assert_eq!(to_camel_case("example"), "Example");
+}
+
+#[test]
+fn test_is_named_type() {
+    assert!(is_named_type("Foo"));
+    assert!(!is_named_type("String"));
+    assert!(is_named_type("Vec<Foo>"));
+    assert!(!is_named_type("Vec<String>"));
+}
+
+#[test]
+fn test_schema_to_type() {
+    assert_eq!(schema_to_type(&json!({"type": "string"})), "String");
+    assert_eq!(schema_to_type(&json!({"type": "integer"})), "i32");
+    assert_eq!(schema_to_type(&json!({"type": "array", "items": {"type": "number"}})), "Vec<f64>");
+    assert_eq!(schema_to_type(&json!({"$ref": "#/components/schemas/item"})), "Item");
+    assert_eq!(schema_to_type(&json!({"type": "array", "items": {"$ref": "#/components/schemas/item"}})), "Vec<Item>");
+}
+
+#[test]
+fn test_extract_fields() {
+    let schema = json!({
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+            "id": {"type": "string"},
+            "age": {"type": "integer"}
+        }
+    });
+    let fields = extract_fields(&schema);
+    assert_eq!(fields.len(), 2);
+    let id = fields.iter().find(|f| f.name == "id").unwrap();
+    assert_eq!(id.ty, "String");
+    assert!(!id.optional);
+    assert_eq!(id.value, "\"example\".to_string()");
+    let age = fields.iter().find(|f| f.name == "age").unwrap();
+    assert_eq!(age.ty, "i32");
+    assert!(age.optional);
+    assert_eq!(age.value, "Some(42)");
+}
+
+#[test]
+fn test_process_schema_type_and_parameter_to_field() {
+    let mut types: HashMap<String, TypeDefinition> = HashMap::new();
+    let schema = json!({
+        "type": "object",
+        "properties": { "flag": {"type": "boolean"} }
+    });
+    process_schema_type("sample", &schema, &mut types);
+    let ty = types.get("Sample").expect("type inserted");
+    assert_eq!(ty.name, "Sample");
+    assert_eq!(ty.fields.len(), 1);
+
+    let param = ParameterMeta {
+        name: "flag".to_string(),
+        location: ParameterLocation::Query,
+        required: false,
+        schema: Some(json!({"type": "boolean"})),
+    };
+    let field = parameter_to_field(&param);
+    assert_eq!(field.name, "flag");
+    assert_eq!(field.ty, "bool");
+    assert!(field.optional);
+    assert_eq!(field.value, "Some(true)");
+}
+
+#[test]
+fn test_rust_literal_for_example() {
+    let mut field = FieldDef {
+        name: "count".to_string(),
+        ty: "i32".to_string(),
+        optional: false,
+        value: "0".to_string(),
+    };
+    let lit = rust_literal_for_example(&field, &json!(3));
+    assert_eq!(lit, "3");
+
+    field.optional = true;
+    field.ty = "String".to_string();
+    let lit = rust_literal_for_example(&field, &json!("foo"));
+    assert_eq!(lit, "Some(\"foo\".to_string())");
+}


### PR DESCRIPTION
## Summary
- make generator module public
- expose helper functions used by the generator
- add generator tests covering camel case, schema parsing, field extraction and more

## Testing
- `cargo test --quiet`