### PR TITLE
Add unit tests for dummy values, echo handler, and path regex

### DIFF
--- a/src/dummy_value.rs
+++ b/src/dummy_value.rs
@@ -11,3 +11,58 @@ pub fn dummy_value(ty: &str) -> askama::Result<String> {
     };
     Ok(value.to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::dummy_value;
+
+    #[test]
+    fn test_string() {
+        assert_eq!(dummy_value("String").unwrap(), "\"example\".to_string()");
+    }
+
+    #[test]
+    fn test_i32() {
+        assert_eq!(dummy_value("i32").unwrap(), "42");
+    }
+
+    #[test]
+    fn test_f64() {
+        assert_eq!(dummy_value("f64").unwrap(), "3.14");
+    }
+
+    #[test]
+    fn test_bool() {
+        assert_eq!(dummy_value("bool").unwrap(), "true");
+    }
+
+    #[test]
+    fn test_vec_string() {
+        assert_eq!(dummy_value("Vec<String>").unwrap(), "vec![]");
+    }
+
+    #[test]
+    fn test_vec_i32() {
+        assert_eq!(dummy_value("Vec<i32>").unwrap(), "vec![]");
+    }
+
+    #[test]
+    fn test_vec_f64() {
+        assert_eq!(dummy_value("Vec<f64>").unwrap(), "vec![]");
+    }
+
+    #[test]
+    fn test_vec_bool() {
+        assert_eq!(dummy_value("Vec<bool>").unwrap(), "vec![]");
+    }
+
+    #[test]
+    fn test_vec_value() {
+        assert_eq!(dummy_value("Vec<Value>").unwrap(), "vec![]");
+    }
+
+    #[test]
+    fn test_default() {
+        assert_eq!(dummy_value("Other").unwrap(), "Default::default()");
+    }
+}

--- a/src/echo.rs
+++ b/src/echo.rs
@@ -16,3 +16,48 @@ pub fn echo_handler(req: HandlerRequest) {
 
     let _ = req.reply_tx.send(response);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::echo_handler;
+    use crate::dispatcher::{HandlerRequest, HandlerResponse};
+    use http::Method;
+    use may::sync::mpsc;
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_echo_handler() {
+        let (tx, rx) = mpsc::channel::<HandlerResponse>();
+        let mut params = HashMap::new();
+        params.insert("id".to_string(), "123".to_string());
+        let mut query = HashMap::new();
+        query.insert("debug".to_string(), "true".to_string());
+        let body = json!({"name": "test"});
+
+        let req = HandlerRequest {
+            method: Method::POST,
+            path: "/items/123".to_string(),
+            handler_name: "echo".to_string(),
+            path_params: params.clone(),
+            query_params: query.clone(),
+            body: Some(body.clone()),
+            reply_tx: tx,
+        };
+
+        echo_handler(req);
+        let resp = rx.recv().unwrap();
+        assert_eq!(resp.status, 200);
+        assert_eq!(
+            resp.body,
+            json!({
+                "handler": "echo",
+                "method": "POST",
+                "path": "/items/123",
+                "params": params,
+                "query": query,
+                "body": Some(body)
+            })
+        );
+    }
+}

--- a/src/router.rs
+++ b/src/router.rs
@@ -118,3 +118,29 @@ impl Router {
         (regex, param_names)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Router;
+
+    #[test]
+    fn test_root_path() {
+        let (re, params) = Router::path_to_regex("/");
+        assert!(re.is_match("/"));
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn test_parameterized_path() {
+        let (re, params) = Router::path_to_regex("/items/{id}");
+        assert!(re.is_match("/items/123"));
+        assert_eq!(params, vec!["id"]);
+    }
+
+    #[test]
+    fn test_nested_path() {
+        let (re, params) = Router::path_to_regex("/a/{b}/c");
+        assert!(re.is_match("/a/1/c"));
+        assert_eq!(params, vec!["b"]);
+    }
+}


### PR DESCRIPTION
## Summary
- add comprehensive tests for `dummy_value` helper
- verify `echo_handler` returns expected fields
- test `Router::path_to_regex` for several patterns

## Testing
- `cargo test`