### PR TITLE
Dynamic registration support

### DIFF
--- a/examples/pet_store/src/main.rs
+++ b/examples/pet_store/src/main.rs
@@ -7,10 +7,10 @@ fn main() -> io::Result<()> {
     let (routes, _slug) =
         brrtrouter::spec::load_spec("./openapi.yaml").expect("failed to load OpenAPI spec");
 
-    let router = Router::new(routes);
+    let router = Router::new(routes.clone());
     let mut dispatcher = Dispatcher::new();
     unsafe {
-        registry::register_all(&mut dispatcher);
+        registry::register_from_spec(&mut dispatcher, &routes);
     }
 
     let service = AppService { router, dispatcher };

--- a/examples/pet_store/src/registry.rs
+++ b/examples/pet_store/src/registry.rs
@@ -2,6 +2,8 @@
 use crate::controllers::*;
 use crate::handlers::*;
 use brrtrouter::dispatcher::Dispatcher;
+use brrtrouter::spec::RouteMeta;
+use brrtrouter::typed::spawn_typed;
 
 pub unsafe fn register_all(dispatcher: &mut Dispatcher) {
     dispatcher.register_typed(
@@ -29,4 +31,53 @@ pub unsafe fn register_all(dispatcher: &mut Dispatcher) {
         crate::controllers::list_user_posts::ListUserPostsController,
     );
     dispatcher.register_typed("get_post", crate::controllers::get_post::GetPostController);
+}
+
+/// Dynamically register handlers for the provided routes using their handler names.
+pub unsafe fn register_from_spec(dispatcher: &mut Dispatcher, routes: &[RouteMeta]) {
+    for route in routes {
+        match route.handler_name.as_str() {
+            "admin_settings" => {
+                let tx = spawn_typed::<crate::handlers::admin_settings::Request, crate::handlers::admin_settings::Response, crate::controllers::admin_settings::AdminSettingsController>(crate::controllers::admin_settings::AdminSettingsController);
+                dispatcher.add_route(route.clone(), tx);
+            }
+            "get_item" => {
+                let tx = spawn_typed::<crate::handlers::get_item::Request, crate::handlers::get_item::Response, crate::controllers::get_item::GetItemController>(crate::controllers::get_item::GetItemController);
+                dispatcher.add_route(route.clone(), tx);
+            }
+            "post_item" => {
+                let tx = spawn_typed::<crate::handlers::post_item::Request, crate::handlers::post_item::Response, crate::controllers::post_item::PostItemController>(crate::controllers::post_item::PostItemController);
+                dispatcher.add_route(route.clone(), tx);
+            }
+            "list_pets" => {
+                let tx = spawn_typed::<crate::handlers::list_pets::Request, crate::handlers::list_pets::Response, crate::controllers::list_pets::ListPetsController>(crate::controllers::list_pets::ListPetsController);
+                dispatcher.add_route(route.clone(), tx);
+            }
+            "add_pet" => {
+                let tx = spawn_typed::<crate::handlers::add_pet::Request, crate::handlers::add_pet::Response, crate::controllers::add_pet::AddPetController>(crate::controllers::add_pet::AddPetController);
+                dispatcher.add_route(route.clone(), tx);
+            }
+            "get_pet" => {
+                let tx = spawn_typed::<crate::handlers::get_pet::Request, crate::handlers::get_pet::Response, crate::controllers::get_pet::GetPetController>(crate::controllers::get_pet::GetPetController);
+                dispatcher.add_route(route.clone(), tx);
+            }
+            "list_users" => {
+                let tx = spawn_typed::<crate::handlers::list_users::Request, crate::handlers::list_users::Response, crate::controllers::list_users::ListUsersController>(crate::controllers::list_users::ListUsersController);
+                dispatcher.add_route(route.clone(), tx);
+            }
+            "get_user" => {
+                let tx = spawn_typed::<crate::handlers::get_user::Request, crate::handlers::get_user::Response, crate::controllers::get_user::GetUserController>(crate::controllers::get_user::GetUserController);
+                dispatcher.add_route(route.clone(), tx);
+            }
+            "list_user_posts" => {
+                let tx = spawn_typed::<crate::handlers::list_user_posts::Request, crate::handlers::list_user_posts::Response, crate::controllers::list_user_posts::ListUserPostsController>(crate::controllers::list_user_posts::ListUserPostsController);
+                dispatcher.add_route(route.clone(), tx);
+            }
+            "get_post" => {
+                let tx = spawn_typed::<crate::handlers::get_post::Request, crate::handlers::get_post::Response, crate::controllers::get_post::GetPostController>(crate::controllers::get_post::GetPostController);
+                dispatcher.add_route(route.clone(), tx);
+            }
+            _ => {}
+        }
+    }
 }

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -6,6 +6,7 @@ use may::coroutine;
 use may::sync::mpsc;
 use serde::Serialize;
 use serde_json::Value;
+use crate::spec::RouteMeta;
 use std::collections::HashMap;
 #[allow(unused_imports)]
 use std::sync::Arc;
@@ -44,6 +45,12 @@ impl Dispatcher {
     #[allow(dead_code)]
     fn default() -> Self {
         Self::new()
+    }
+
+    /// Add a handler sender for the given route metadata. This allows handlers
+    /// to be registered after the dispatcher has been created.
+    pub fn add_route(&mut self, route: RouteMeta, sender: HandlerSender) {
+        self.handlers.insert(route.handler_name, sender);
     }
 
     /// Registers a handler function that will process incoming requests with the given name.

--- a/tests/dynamic_registration.rs
+++ b/tests/dynamic_registration.rs
@@ -1,0 +1,37 @@
+use brrtrouter::{dispatcher::Dispatcher, load_spec, router::Router};
+use http::Method;
+use pet_store::registry;
+
+#[test]
+fn test_dynamic_register_get_pet() {
+    let (routes, _slug) = load_spec("examples/openapi.yaml").expect("load spec");
+    let router = Router::new(routes.clone());
+    let mut dispatcher = Dispatcher::new();
+    unsafe {
+        registry::register_from_spec(&mut dispatcher, &routes);
+    }
+
+    let route_match = router
+        .route(Method::GET, "/pets/12345")
+        .expect("route match");
+    let resp = dispatcher.dispatch(route_match, None).expect("dispatch");
+    assert_eq!(resp.status, 200);
+}
+
+#[test]
+fn test_dynamic_register_post_item() {
+    let (routes, _slug) = load_spec("examples/openapi.yaml").expect("load spec");
+    let router = Router::new(routes.clone());
+    let mut dispatcher = Dispatcher::new();
+    unsafe {
+        registry::register_from_spec(&mut dispatcher, &routes);
+    }
+
+    let route_match = router
+        .route(Method::POST, "/items/item-001")
+        .expect("route match");
+    let resp = dispatcher
+        .dispatch(route_match, Some(serde_json::json!({"name": "New Item"})))
+        .expect("dispatch");
+    assert_eq!(resp.status, 200);
+}


### PR DESCRIPTION
## Summary
- allow handlers to be inserted into a Dispatcher after creation
- add helper to spawn typed handlers
- generate a registry helper to register from a spec dynamically
- update pet_store example to use dynamic registration
- test dynamic registration and dispatch

## Testing
- `cargo test`