### PR TITLE
Add validator helper and tests

### DIFF
--- a/src/bin/validator_helper.rs
+++ b/src/bin/validator_helper.rs
@@ -1,0 +1,25 @@
+use brrtrouter::validator::{print_issues, fail_if_issues, ValidationIssue};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    match args.next().as_deref() {
+        Some("print") => {
+            let issues = sample_issues();
+            print_issues(&issues);
+        }
+        Some("fail") => {
+            let issues = sample_issues();
+            fail_if_issues(issues);
+        }
+        _ => {
+            eprintln!("unknown mode");
+        }
+    }
+}
+
+fn sample_issues() -> Vec<ValidationIssue> {
+    vec![
+        ValidationIssue::new("loc1", "Error", "message1"),
+        ValidationIssue::new("loc2", "Warning", "message2"),
+    ]
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,6 @@ pub mod router;
 pub mod server;
 pub mod spec;
 pub mod typed;
-mod validator;
+pub mod validator;
 
 pub use spec::{load_spec, load_spec_from_spec, ParameterLocation, ParameterMeta, RouteMeta};

--- a/tests/validator_tests.rs
+++ b/tests/validator_tests.rs
@@ -1,0 +1,30 @@
+use std::process::Command;
+
+#[test]
+fn test_print_issues_output() {
+    let exe = env!("CARGO_BIN_EXE_validator_helper");
+    let output = Command::new(exe)
+        .arg("print")
+        .output()
+        .expect("failed to run helper");
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("OpenAPI spec validation failed. 2 issue(s) found"));
+    assert!(stderr.contains("[Error] loc1: message1"));
+    assert!(stderr.contains("[Warning] loc2: message2"));
+    assert!(stderr.contains("Please fix the issues"));
+}
+
+#[test]
+fn test_fail_if_issues_exit_code_and_output() {
+    let exe = env!("CARGO_BIN_EXE_validator_helper");
+    let output = Command::new(exe)
+        .arg("fail")
+        .output()
+        .expect("failed to run helper");
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("[Error] loc1: message1"));
+    assert!(stderr.contains("[Warning] loc2: message2"));
+}


### PR DESCRIPTION
## Summary
- expose validator module for testing
- add a helper binary used in validator tests
- implement integration tests for `print_issues` and `fail_if_issues`

## Testing
- `cargo test --quiet`