### PR TITLE
Improve spec validation tests

### DIFF
--- a/src/bin/spec_helper.rs
+++ b/src/bin/spec_helper.rs
@@ -1,0 +1,15 @@
+use brrtrouter::load_spec;
+
+fn main() {
+    let path = std::env::args().nth(1).expect("spec path");
+    match load_spec(&path) {
+        Ok((routes, slug)) => {
+            println!("routes: {}", routes.len());
+            println!("slug: {}", slug);
+        }
+        Err(err) => {
+            eprintln!("error: {err}");
+            std::process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add helper binary to execute spec loading
- extend spec tests with negative cases for missing operationId and unsupported methods

## Testing
- `cargo test --test spec_tests -- --test-threads=1`
- `cargo test`