### PR TITLE
Add header and cookie support

### DIFF
--- a/src/dispatcher/core.rs
+++ b/src/dispatcher/core.rs
@@ -18,6 +18,8 @@ pub struct HandlerRequest {
     pub handler_name: String,
     pub path_params: HashMap<String, String>,
     pub query_params: HashMap<String, String>,
+    pub headers: HashMap<String, String>,
+    pub cookies: HashMap<String, String>,
     pub body: Option<Value>,
     pub reply_tx: mpsc::Sender<HandlerResponse>,
 }
@@ -100,6 +102,8 @@ impl Dispatcher {
         &self,
         route_match: RouteMatch,
         body: Option<Value>,
+        headers: HashMap<String, String>,
+        cookies: HashMap<String, String>,
     ) -> Option<HandlerResponse> {
         let (reply_tx, reply_rx) = mpsc::channel();
 
@@ -112,6 +116,8 @@ impl Dispatcher {
             handler_name: handler_name.clone(),
             path_params: route_match.path_params.clone(),
             query_params: route_match.query_params.clone(),
+            headers,
+            cookies,
             body,
             reply_tx,
         };

--- a/src/echo.rs
+++ b/src/echo.rs
@@ -43,6 +43,8 @@ mod tests {
             handler_name: "echo".to_string(),
             path_params: params.clone(),
             query_params: query.clone(),
+            headers: HashMap::new(),
+            cookies: HashMap::new(),
             body: Some(body.clone()),
             reply_tx: tx,
         };

--- a/templates/handler.rs.txt
+++ b/templates/handler.rs.txt
@@ -62,8 +62,12 @@ impl TryFrom<HandlerRequest> for Request {
         {% for p in parameters %}
         {% if p.location == crate::spec::ParameterLocation::Path %}
         if let Some(v) = req.path_params.get("{{ p.name }}") {
-        {% else %}
+        {% elif p.location == crate::spec::ParameterLocation::Query %}
         if let Some(v) = req.query_params.get("{{ p.name }}") {
+        {% elif p.location == crate::spec::ParameterLocation::Header %}
+        if let Some(v) = req.headers.get("{{ p.name | lower }}") {
+        {% else %}
+        if let Some(v) = req.cookies.get("{{ p.name }}") {
         {% endif %}
             data_map.insert(
                 "{{ p.name }}".to_string(),

--- a/tests/dispatcher_tests.rs
+++ b/tests/dispatcher_tests.rs
@@ -81,6 +81,8 @@ fn test_dispatch_post_item() {
         handler_name: handler_name.clone(),
         path_params,
         query_params,
+        headers: HashMap::new(),
+        cookies: HashMap::new(),
         body: Some(body),
         reply_tx,
     };
@@ -120,6 +122,8 @@ fn test_dispatch_get_pet() {
         handler_name: handler_name.clone(),
         path_params,
         query_params,
+        headers: HashMap::new(),
+        cookies: HashMap::new(),
         body: None,
         reply_tx,
     };
@@ -164,6 +168,8 @@ fn test_typed_controller_params() {
         handler_name: "assert_controller".to_string(),
         path_params,
         query_params,
+        headers: HashMap::new(),
+        cookies: HashMap::new(),
         body: None,
         reply_tx,
     };
@@ -199,6 +205,8 @@ fn test_typed_controller_invalid_params() {
         handler_name: "assert_controller".to_string(),
         path_params,
         query_params,
+        headers: HashMap::new(),
+        cookies: HashMap::new(),
         body: None,
         reply_tx,
     };
@@ -233,6 +241,8 @@ fn test_panic_handler_returns_500() {
         handler_name: "panic".to_string(),
         path_params: HashMap::new(),
         query_params: HashMap::new(),
+        headers: HashMap::new(),
+        cookies: HashMap::new(),
         body: None,
         reply_tx,
     };
@@ -333,7 +343,12 @@ fn test_dispatch_all_registry_handlers() {
         let route_match = router.route(method.clone(), path).expect("route match");
         assert_eq!(route_match.handler_name, name);
         let resp = dispatcher
-            .dispatch(route_match, body.clone())
+            .dispatch(
+                route_match,
+                body.clone(),
+                Default::default(),
+                Default::default(),
+            )
             .expect("dispatch");
         assert_eq!(resp.status, 200, "handler {}", name);
         // TODO: fix this assertion once the handlers return correct responses

--- a/tests/dynamic_registration.rs
+++ b/tests/dynamic_registration.rs
@@ -14,7 +14,9 @@ fn test_dynamic_register_get_pet() {
     let route_match = router
         .route(Method::GET, "/pets/12345")
         .expect("route match");
-    let resp = dispatcher.dispatch(route_match, None).expect("dispatch");
+    let resp = dispatcher
+        .dispatch(route_match, None, Default::default(), Default::default())
+        .expect("dispatch");
     assert_eq!(resp.status, 200);
 }
 
@@ -31,7 +33,12 @@ fn test_dynamic_register_post_item() {
         .route(Method::POST, "/items/item-001")
         .expect("route match");
     let resp = dispatcher
-        .dispatch(route_match, Some(serde_json::json!({"name": "New Item"})))
+        .dispatch(
+            route_match,
+            Some(serde_json::json!({"name": "New Item"})),
+            Default::default(),
+            Default::default(),
+        )
         .expect("dispatch");
     assert_eq!(resp.status, 200);
 }


### PR DESCRIPTION
## Summary
- extend `HandlerRequest` with `headers` and `cookies`
- parse headers and cookies in `AppService`
- pass header and cookie maps through `Dispatcher::dispatch`
- update handler template for header and cookie params
- test header and cookie extraction

## Testing
- `cargo test --quiet`