### PR TITLE
Add hot reload support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
@@ -141,6 +147,7 @@ dependencies = [
  "http",
  "may",
  "may_minihttp",
+ "notify",
  "oas3",
  "pet_store",
  "pretty_assertions",
@@ -336,6 +343,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +367,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -523,6 +551,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,10 +583,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "litemap"
@@ -626,16 +705,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.9.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -692,7 +802,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -749,7 +859,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "memchr",
  "unicase",
 ]
@@ -769,7 +879,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -818,6 +928,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -991,6 +1110,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1140,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1115,11 +1259,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1128,7 +1281,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1137,15 +1305,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1155,9 +1329,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1173,9 +1359,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1185,9 +1383,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ regex = "1.11.1"
 url = "2.5.4"
 clap = { version = "4.5.38", features = ["cargo", "env", "derive"] }
 askama = { version = "0.14.0", features = ["full"] }
+notify = "6"
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/examples/pet_store/src/main.rs
+++ b/examples/pet_store/src/main.rs
@@ -4,15 +4,22 @@ use pet_store::registry;
 use std::io;
 
 fn main() -> io::Result<()> {
+    // Load OpenAPI spec and create router
     let (routes, _slug) =
         brrtrouter::spec::load_spec("./openapi.yaml").expect("failed to load OpenAPI spec");
-
     let router = Router::new(routes.clone());
+
+    // Create dispatcher and register handlers
     let mut dispatcher = Dispatcher::new();
     unsafe {
         registry::register_from_spec(&mut dispatcher, &routes);
     }
 
+    // Start the HTTP server on port 8080, binding to 127.0.0.1 if BRRTR_LOCAL is
+    // set for local testing.
+    // This returns a coroutine JoinHandle; we join on it to keep the server running
+    let router = std::sync::Arc::new(std::sync::RwLock::new(Router::new(routes)));
+    let dispatcher = std::sync::Arc::new(std::sync::RwLock::new(Dispatcher::new()));
     let service = AppService { router, dispatcher };
     let addr = if std::env::var("BRRTR_LOCAL").is_ok() {
         "127.0.0.1:8080"
@@ -25,6 +32,6 @@ fn main() -> io::Result<()> {
 
     server
         .join()
-        .map_err(|e| io::Error::other(format!("Server failed: {:?}", e)))?;
+        .map_err(|e| io::Error::other(format!("Server encountered an error: {:?}", e)))?;
     Ok(())
 }

--- a/examples/pet_store/src/main.rs
+++ b/examples/pet_store/src/main.rs
@@ -1,19 +1,34 @@
-use brrtrouter::{dispatcher::Dispatcher, router::Router, server::AppService};
+use brrtrouter::{dispatcher::Dispatcher, router::Router, server::AppService, hot_reload};
 use may_minihttp::HttpServer;
 use pet_store::registry;
 use std::io;
+use std::sync::{Arc, RwLock};
 
 fn main() -> io::Result<()> {
     let (routes, _slug) =
         brrtrouter::spec::load_spec("./openapi.yaml").expect("failed to load OpenAPI spec");
 
-    let router = Router::new(routes.clone());
-    let mut dispatcher = Dispatcher::new();
+    let router = Arc::new(RwLock::new(Router::new(routes.clone())));
+    let dispatcher = Arc::new(RwLock::new(Dispatcher::new()));
     unsafe {
-        registry::register_from_spec(&mut dispatcher, &routes);
+        registry::register_from_spec(&mut dispatcher.write().unwrap(), &routes);
     }
+    // Watch the spec file and reload routes on changes
+    let _watcher = hot_reload::watch_spec(
+        "./openapi.yaml",
+        Arc::clone(&router),
+        {
+            let dispatcher = Arc::clone(&dispatcher);
+            move |routes| {
+                let mut d = dispatcher.write().unwrap();
+                d.handlers.clear();
+                unsafe { registry::register_from_spec(&mut d, &routes) };
+            }
+        },
+    )
+    .expect("failed to watch spec");
 
-    let service = AppService { router, dispatcher };
+    let service = AppService { router, dispatcher }; 
     let addr = if std::env::var("BRRTR_LOCAL").is_ok() {
         "127.0.0.1:8080"
     } else {

--- a/src/hot_reload.rs
+++ b/src/hot_reload.rs
@@ -1,0 +1,43 @@
+use crate::{router::Router, spec::{self, RouteMeta}};
+use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+
+/// Watch an OpenAPI spec file and rebuild the [`Router`] when it changes.
+///
+/// The provided callback will receive the reloaded routes so the caller can
+/// rebuild dispatcher mappings or perform additional work.
+pub fn watch_spec<P, F>(
+    spec_path: P,
+    router: Arc<RwLock<Router>>, 
+    mut on_reload: F,
+) -> notify::Result<RecommendedWatcher>
+where
+    P: AsRef<Path>,
+    F: FnMut(Vec<RouteMeta>) + Send + 'static,
+{
+    let path: PathBuf = spec_path.as_ref().to_path_buf();
+    let watch_path = path.clone();
+
+    let mut watcher = RecommendedWatcher::new(
+        move |res| match res {
+            Ok(event) => {
+                if matches!(event.kind, EventKind::Modify(_) | EventKind::Create(_)) {
+                    if let Ok((routes, _)) = spec::load_spec(watch_path.to_str().unwrap()) {
+                        let new_router = Router::new(routes.clone());
+                        if let Ok(mut r) = router.write() {
+                            *r = new_router;
+                        }
+                        on_reload(routes);
+                    }
+                }
+            }
+            Err(e) => eprintln!("watch error: {:?}", e),
+        },
+        Config::default(),
+    )?;
+
+    watcher.watch(&path, RecursiveMode::NonRecursive)?;
+    Ok(watcher)
+}
+

--- a/src/hot_reload.rs
+++ b/src/hot_reload.rs
@@ -20,7 +20,7 @@ where
     let watch_path = path.clone();
 
     let mut watcher = RecommendedWatcher::new(
-        move |res| match res {
+        move |res: Result<notify::Event, notify::Error>| match res {
             Ok(event) => {
                 if matches!(event.kind, EventKind::Modify(_) | EventKind::Create(_)) {
                     if let Ok((routes, _)) = spec::load_spec(watch_path.to_str().unwrap()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,5 +9,6 @@ pub mod server;
 pub mod spec;
 pub mod typed;
 pub mod validator;
+pub mod hot_reload;
 
 pub use spec::{load_spec, load_spec_from_spec, ParameterLocation, ParameterMeta, RouteMeta};

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> io::Result<()> {
     let router = Router::new(routes.clone());
 
     // Create dispatcher and register handlers
-    let dispatcher = Dispatcher::new();
+    let mut dispatcher = Dispatcher::new();
     // unsafe {
     //     registry::register_all(&mut dispatcher);
     // }
@@ -27,8 +27,12 @@ fn main() -> io::Result<()> {
     } else {
         "0.0.0.0:8080"
     };
-    let server = HttpServer(service).start(addr).map_err(io::Error::other)?;
+    println!("🚀 {{ name }} example server listening on {addr}");
+    let server = HttpServer(service)
+        .start(addr)
+        .map_err(io::Error::other)?;
     println!("Server started successfully on {addr}");
+
     server
         .join()
         .map_err(|e| io::Error::other(format!("Server encountered an error: {:?}", e)))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::io;
 fn main() -> io::Result<()> {
     // Load OpenAPI spec and create router
     let (routes, _slug) = load_spec("examples/openapi.yaml").expect("failed to load spec");
-    let router = Router::new(routes);
+    let router = Router::new(routes.clone());
 
     // Create dispatcher and register handlers
     let dispatcher = Dispatcher::new();
@@ -19,6 +19,8 @@ fn main() -> io::Result<()> {
     // Start the HTTP server on port 8080, binding to 127.0.0.1 if BRRTR_LOCAL is
     // set for local testing.
     // This returns a coroutine JoinHandle; we join on it to keep the server running
+    let router = std::sync::Arc::new(std::sync::RwLock::new(Router::new(routes)));
+    let dispatcher = std::sync::Arc::new(std::sync::RwLock::new(Dispatcher::new()));
     let service = AppService { router, dispatcher };
     let addr = if std::env::var("BRRTR_LOCAL").is_ok() {
         "127.0.0.1:8080"

--- a/templates/main.rs.txt
+++ b/templates/main.rs.txt
@@ -9,15 +9,21 @@ use may_minihttp::HttpServer;
 use std::io;
 
 fn main() -> io::Result<()> {
-    let (routes, _slug) = brrtrouter::spec::load_spec("./openapi.yaml")
-        .expect("failed to load OpenAPI spec");
-
+    // Load OpenAPI spec and create router
+    let (routes, _slug) = brrtrouter::spec::load_spec("./openapi.yaml").expect("failed to load OpenAPI spec");
     let router = Router::new(routes.clone());
+
+    // Create dispatcher and register handlers
     let mut dispatcher = Dispatcher::new();
     unsafe {
         registry::register_from_spec(&mut dispatcher, &routes);
     }
 
+    // Start the HTTP server on port 8080, binding to 127.0.0.1 if BRRTR_LOCAL is
+    // set for local testing.
+    // This returns a coroutine JoinHandle; we join on it to keep the server running
+    let router = std::sync::Arc::new(std::sync::RwLock::new(Router::new(routes)));
+    let dispatcher = std::sync::Arc::new(std::sync::RwLock::new(Dispatcher::new()));
     let service = AppService { router, dispatcher };
     let addr = if std::env::var("BRRTR_LOCAL").is_ok() {
         "127.0.0.1:8080"
@@ -32,6 +38,6 @@ fn main() -> io::Result<()> {
 
     server
         .join()
-        .map_err(|e| io::Error::other(format!("Server failed: {:?}", e)))?;
+        .map_err(|e| io::Error::other(format!("Server encountered an error: {:?}", e)))?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- watch spec file via notify and update router on changes
- hold Router and Dispatcher in `AppService` behind `Arc<RwLock<>>`
- reload routes live in the pet_store example

## Testing
- `cargo test` *(fails: failed to download dependencies)*