### PR TITLE
Support multi-status responses

### DIFF
--- a/tests/spec_helpers_tests.rs
+++ b/tests/spec_helpers_tests.rs
@@ -95,9 +95,11 @@ fn test_extract_request_and_response() {
     let req = extract_request_schema(&spec, bar_op).unwrap();
     assert_eq!(req["properties"]["count"]["type"], "integer");
 
-    let (resp, example) = extract_response_schema_and_example(&spec, bar_op);
+    let (resp, example, all) = extract_response_schema_and_example(&spec, bar_op);
     assert_eq!(resp.unwrap()["properties"]["id"]["type"], "string");
     assert_eq!(example.unwrap(), json!({"id": "xyz"}));
+    let meta = all.get(&200).unwrap().get("application/json").unwrap();
+    assert_eq!(meta.example.as_ref().unwrap(), &json!({"id": "xyz"}));
 }
 
 #[test]

--- a/tests/spec_tests.rs
+++ b/tests/spec_tests.rs
@@ -105,6 +105,7 @@ fn test_load_spec_yaml_and_json() {
     assert!(route_y.request_schema.is_some());
     assert!(route_y.response_schema.is_some());
     assert!(route_y.example.is_some());
+    assert!(route_y.responses.contains_key(&200));
     assert_eq!(route_y.example, route_j.example);
     assert_eq!(route_y.example_name, "test_api_example");
 }


### PR DESCRIPTION
## Summary
- extend spec loader to collect schemas and examples for all response codes
- store collected response metadata in `RouteMeta`
- choose HTTP status and content type in `AppService`
- test JSON and text responses, including 201 Created

## Testing
- `cargo test --quiet`