### PR TITLE
Add security scheme support

### DIFF
--- a/examples/pet_store/src/main.rs
+++ b/examples/pet_store/src/main.rs
@@ -1,7 +1,7 @@
 use brrtrouter::{dispatcher::Dispatcher, router::Router, server::AppService};
-use std::collections::HashMap;
 use may_minihttp::HttpServer;
 use pet_store::registry;
+use std::collections::HashMap;
 use std::io;
 
 fn main() -> io::Result<()> {

--- a/examples/pet_store/src/main.rs
+++ b/examples/pet_store/src/main.rs
@@ -1,4 +1,5 @@
 use brrtrouter::{dispatcher::Dispatcher, router::Router, server::AppService};
+use std::collections::HashMap;
 use may_minihttp::HttpServer;
 use pet_store::registry;
 use std::io;
@@ -20,7 +21,7 @@ fn main() -> io::Result<()> {
     // This returns a coroutine JoinHandle; we join on it to keep the server running
     let router = std::sync::Arc::new(std::sync::RwLock::new(Router::new(routes)));
     let dispatcher = std::sync::Arc::new(std::sync::RwLock::new(Dispatcher::new()));
-    let service = AppService { router, dispatcher };
+    let service = AppService::new(router, dispatcher, HashMap::new());
     let addr = if std::env::var("BRRTR_LOCAL").is_ok() {
         "127.0.0.1:8080"
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,21 @@ mod dummy_value;
 mod echo;
 pub mod generator;
 pub mod hot_reload;
+pub mod security;
 pub mod router;
 pub mod server;
 pub mod spec;
 pub mod typed;
 pub mod validator;
 
-pub use spec::{load_spec, load_spec_from_spec, ParameterLocation, ParameterMeta, RouteMeta};
+pub use spec::{
+    load_spec,
+    load_spec_full,
+    load_spec_from_spec,
+    ParameterLocation,
+    ParameterMeta,
+    RouteMeta,
+    SecurityRequirement,
+    SecurityScheme,
+};
+pub use security::{SecurityProvider, SecurityRequest};

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,13 +8,13 @@ use std::io;
 
 fn main() -> io::Result<()> {
     // Load OpenAPI spec and create router
-    let (routes, _slug) = load_spec("examples/openapi.yaml").expect("failed to load spec");
+    let (routes, _slug) = load_spec("examples/openapi.yaml").expect("failed to load OpenAPI spec");
     let router = Router::new(routes.clone());
 
     // Create dispatcher and register handlers
     let mut dispatcher = Dispatcher::new();
     // unsafe {
-    //     registry::register_all(&mut dispatcher);
+    //     registry::register_all(&mut dispatcher, &routes);
     // }
 
     // Start the HTTP server on port 8080, binding to 127.0.0.1 if BRRTR_LOCAL is
@@ -29,7 +29,9 @@ fn main() -> io::Result<()> {
         "0.0.0.0:8080"
     };
     println!("🚀 {{ name }} example server listening on {addr}");
-    let server = HttpServer(service).start(addr).map_err(io::Error::other)?;
+    let server = HttpServer(service)
+        .start(addr)
+        .map_err(io::Error::other)?;
     println!("Server started successfully on {addr}");
 
     server

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use brrtrouter::dispatcher::Dispatcher;
 // use brrrouter::registry;
 use brrtrouter::server::AppService;
 use brrtrouter::{load_spec, router::Router};
+use std::collections::HashMap;
 use may_minihttp::HttpServer;
 use std::io;
 
@@ -21,7 +22,7 @@ fn main() -> io::Result<()> {
     // This returns a coroutine JoinHandle; we join on it to keep the server running
     let router = std::sync::Arc::new(std::sync::RwLock::new(Router::new(routes)));
     let dispatcher = std::sync::Arc::new(std::sync::RwLock::new(Dispatcher::new()));
-    let service = AppService { router, dispatcher };
+    let service = AppService::new(router, dispatcher, HashMap::new());
     let addr = if std::env::var("BRRTR_LOCAL").is_ok() {
         "127.0.0.1:8080"
     } else {

--- a/src/security.rs
+++ b/src/security.rs
@@ -1,0 +1,19 @@
+use crate::spec::{SecurityScheme};
+use std::collections::HashMap;
+
+pub struct SecurityRequest<'a> {
+    pub headers: &'a HashMap<String, String>,
+    pub query: &'a HashMap<String, String>,
+    pub cookies: &'a HashMap<String, String>,
+}
+
+pub trait SecurityProvider: Send + Sync {
+    fn validate(
+        &self,
+        scheme: &SecurityScheme,
+        scopes: &[String],
+        req: &SecurityRequest,
+    ) -> bool;
+}
+
+

--- a/templates/main.rs.txt
+++ b/templates/main.rs.txt
@@ -4,6 +4,7 @@ use brrtrouter::{
     router::Router,
     server::AppService,
 };
+use std::collections::HashMap;
 use {{ name }}::registry;
 use may_minihttp::HttpServer;
 use std::io;
@@ -24,7 +25,7 @@ fn main() -> io::Result<()> {
     // This returns a coroutine JoinHandle; we join on it to keep the server running
     let router = std::sync::Arc::new(std::sync::RwLock::new(Router::new(routes)));
     let dispatcher = std::sync::Arc::new(std::sync::RwLock::new(Dispatcher::new()));
-    let service = AppService { router, dispatcher };
+    let service = AppService::new(router, dispatcher, HashMap::new());
     let addr = if std::env::var("BRRTR_LOCAL").is_ok() {
         "127.0.0.1:8080"
     } else {

--- a/tests/security_tests.rs
+++ b/tests/security_tests.rs
@@ -1,0 +1,129 @@
+use brrtrouter::{
+    dispatcher::{Dispatcher, HandlerRequest, HandlerResponse},
+    router::Router,
+    server::AppService,
+    SecurityProvider, SecurityRequest,
+    load_spec_full,
+};
+use http::Method;
+use may_minihttp::HttpServer;
+use serde_json::json;
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+use brrtrouter::spec::SecurityScheme;
+
+struct ApiKeyProvider { key: String }
+
+impl SecurityProvider for ApiKeyProvider {
+    fn validate(
+        &self,
+        scheme: &SecurityScheme,
+        _scopes: &[String],
+        req: &SecurityRequest,
+    ) -> bool {
+        match scheme {
+            SecurityScheme::ApiKey { name, location, .. } => {
+                let expected = &self.key;
+                match location.as_str() {
+                    "header" => req.headers.get(&name.to_ascii_lowercase()) == Some(expected),
+                    "query" => req.query.get(name) == Some(expected),
+                    "cookie" => req.cookies.get(name) == Some(expected),
+                    _ => false,
+                }
+            }
+            _ => false,
+        }
+    }
+}
+
+fn write_temp(content: &str) -> std::path::PathBuf {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("sec_spec_{}_{}.yaml", std::process::id(), nanos));
+    std::fs::write(&path, content).unwrap();
+    path
+}
+
+fn start_service() -> (may::coroutine::JoinHandle<()>, SocketAddr) {
+    const SPEC: &str = r#"openapi: 3.1.0
+info:
+  title: Auth API
+  version: '1.0'
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+paths:
+  /secret:
+    get:
+      operationId: secret
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200': { description: OK }
+"#;
+    let path = write_temp(SPEC);
+    let (routes, schemes, _slug) = load_spec_full(path.to_str().unwrap()).unwrap();
+    let router = Arc::new(RwLock::new(Router::new(routes.clone())));
+    let mut dispatcher = Dispatcher::new();
+    unsafe {
+        dispatcher.register_handler("secret", |req: HandlerRequest| {
+            let _ = req.reply_tx.send(HandlerResponse { status: 200, body: json!({"ok": true}) });
+        });
+    }
+    let mut service = AppService::new(router, Arc::new(RwLock::new(dispatcher)), schemes);
+    service.register_security_provider("ApiKeyAuth", Arc::new(ApiKeyProvider { key: "secret".into() }));
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    let handle = HttpServer(service).start(addr).unwrap();
+    std::thread::sleep(Duration::from_millis(50));
+    (handle, addr)
+}
+
+fn send_request(addr: &SocketAddr, req: &str) -> String {
+    let mut stream = TcpStream::connect(addr).unwrap();
+    stream.write_all(req.as_bytes()).unwrap();
+    stream.set_read_timeout(Some(Duration::from_millis(100))).unwrap();
+    let mut buf = Vec::new();
+    loop {
+        let mut tmp = [0u8; 1024];
+        match stream.read(&mut tmp) {
+            Ok(0) => break,
+            Ok(n) => buf.extend_from_slice(&tmp[..n]),
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock || e.kind() == std::io::ErrorKind::TimedOut => break,
+            Err(e) => panic!("read error: {:?}", e),
+        }
+    }
+    String::from_utf8_lossy(&buf).to_string()
+}
+
+fn parse_status(resp: &str) -> u16 {
+    resp.lines()
+        .next()
+        .and_then(|l| l.split_whitespace().nth(1))
+        .unwrap_or("0")
+        .parse()
+        .unwrap()
+}
+
+#[test]
+fn test_api_key_auth() {
+    let (handle, addr) = start_service();
+    let resp = send_request(&addr, "GET /secret HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    let status = parse_status(&resp);
+    assert_eq!(status, 401);
+
+    let resp = send_request(&addr, "GET /secret HTTP/1.1\r\nHost: localhost\r\nX-API-Key: secret\r\n\r\n");
+    unsafe { handle.coroutine().cancel() };
+    let status = parse_status(&resp);
+    assert_eq!(status, 200);
+}

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -8,6 +8,7 @@ use http::Method;
 use may_minihttp::HttpServer;
 use pet_store::registry;
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::path::PathBuf;
@@ -21,10 +22,7 @@ fn start_petstore_service() -> (may::coroutine::JoinHandle<()>, SocketAddr) {
     unsafe {
         registry::register_from_spec(&mut dispatcher, &routes);
     }
-    let service = AppService {
-        router,
-        dispatcher: Arc::new(RwLock::new(dispatcher)),
-    };
+    let service = AppService::new(router, Arc::new(RwLock::new(dispatcher)), HashMap::new());
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
     drop(listener);
@@ -123,6 +121,7 @@ fn test_panic_recovery() {
         response_schema: None,
         example: None,
         responses: std::collections::HashMap::new(),
+        security: Vec::new(),
         example_name: String::new(),
         project_slug: String::new(),
         output_dir: PathBuf::new(),
@@ -133,10 +132,7 @@ fn test_panic_recovery() {
     unsafe {
         dispatcher.register_handler("panic", panic_handler);
     }
-    let service = AppService {
-        router,
-        dispatcher: Arc::new(RwLock::new(dispatcher)),
-    };
+    let service = AppService::new(router, Arc::new(RwLock::new(dispatcher)), HashMap::new());
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
     drop(listener);
@@ -171,6 +167,7 @@ fn test_headers_and_cookies() {
         response_schema: None,
         example: None,
         responses: std::collections::HashMap::new(),
+        security: Vec::new(),
         example_name: String::new(),
         project_slug: String::new(),
         output_dir: PathBuf::new(),
@@ -181,10 +178,7 @@ fn test_headers_and_cookies() {
     unsafe {
         dispatcher.register_handler("header", header_handler);
     }
-    let service = AppService {
-        router,
-        dispatcher: Arc::new(RwLock::new(dispatcher)),
-    };
+    let service = AppService::new(router, Arc::new(RwLock::new(dispatcher)), HashMap::new());
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
     drop(listener);
@@ -227,6 +221,7 @@ fn test_status_201_json() {
         response_schema: None,
         example: None,
         responses: std::collections::HashMap::new(),
+        security: Vec::new(),
         example_name: String::new(),
         project_slug: String::new(),
         output_dir: PathBuf::new(),
@@ -237,10 +232,7 @@ fn test_status_201_json() {
     unsafe {
         dispatcher.register_handler("create", create_handler);
     }
-    let service = AppService {
-        router,
-        dispatcher: Arc::new(RwLock::new(dispatcher)),
-    };
+    let service = AppService::new(router, Arc::new(RwLock::new(dispatcher)), HashMap::new());
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
     drop(listener);
@@ -274,6 +266,7 @@ fn test_text_plain_error() {
         response_schema: None,
         example: None,
         responses: std::collections::HashMap::new(),
+        security: Vec::new(),
         example_name: String::new(),
         project_slug: String::new(),
         output_dir: PathBuf::new(),
@@ -284,10 +277,7 @@ fn test_text_plain_error() {
     unsafe {
         dispatcher.register_handler("text", text_handler);
     }
-    let service = AppService {
-        router,
-        dispatcher: Arc::new(RwLock::new(dispatcher)),
-    };
+    let service = AppService::new(router, Arc::new(RwLock::new(dispatcher)), HashMap::new());
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
     drop(listener);


### PR DESCRIPTION
## Summary
- parse `securitySchemes` and per-operation `security` sections
- implement `SecurityProvider` trait and a request type
- extend `AppService` to register and check security providers
- support security in spec loader
- test API key authentication

## Testing
- `cargo check`
- `cargo test`