### PR TITLE
Add middleware hooks with metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,22 @@ dispatcher.register_handler("post_item", echo_handler);
 Each handler runs in its own coroutine, receiving requests via a channel and sending back structured HandlerResponse.
 
 ---
+## 🔌 Middleware
+
+Middlewares run before and after each handler. Register them on the dispatcher:
+
+```rust
+use brrrouter::middleware::MetricsMiddleware;
+use std::sync::Arc;
+
+let mut dispatcher = Dispatcher::new();
+let metrics = Arc::new(MetricsMiddleware::new());
+dispatcher.add_middleware(metrics.clone());
+```
+
+`MetricsMiddleware` tracks request counts and average latency.
+
+---
 ## 📈 Contributing & Benchmarks
 For a detailed view of completed and upcoming work, see [docs/ROADMAP.md](docs/ROADMAP.md).
 We welcome contributions that improve:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod echo;
 pub mod generator;
 pub mod hot_reload;
 pub mod security;
+pub mod middleware;
 pub mod router;
 pub mod server;
 pub mod spec;

--- a/src/middleware/metrics.rs
+++ b/src/middleware/metrics.rs
@@ -1,0 +1,43 @@
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use super::Middleware;
+use crate::dispatcher::{HandlerRequest, HandlerResponse};
+
+pub struct MetricsMiddleware {
+    request_count: AtomicUsize,
+    total_latency_ns: AtomicU64,
+}
+
+impl MetricsMiddleware {
+    pub fn new() -> Self {
+        Self {
+            request_count: AtomicUsize::new(0),
+            total_latency_ns: AtomicU64::new(0),
+        }
+    }
+
+    pub fn request_count(&self) -> usize {
+        self.request_count.load(Ordering::Relaxed)
+    }
+
+    pub fn average_latency(&self) -> Duration {
+        let count = self.request_count.load(Ordering::Relaxed) as u64;
+        if count == 0 {
+            Duration::from_nanos(0)
+        } else {
+            Duration::from_nanos(self.total_latency_ns.load(Ordering::Relaxed) / count)
+        }
+    }
+}
+
+impl Middleware for MetricsMiddleware {
+    fn before(&self, _req: &HandlerRequest) {
+        self.request_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn after(&self, _req: &HandlerRequest, _res: &HandlerResponse, latency: Duration) {
+        self.total_latency_ns
+            .fetch_add(latency.as_nanos() as u64, Ordering::Relaxed);
+    }
+}

--- a/src/middleware/middleware.rs
+++ b/src/middleware/middleware.rs
@@ -1,0 +1,8 @@
+use std::time::Duration;
+
+use crate::dispatcher::{HandlerRequest, HandlerResponse};
+
+pub trait Middleware: Send + Sync {
+    fn before(&self, _req: &HandlerRequest) {}
+    fn after(&self, _req: &HandlerRequest, _res: &HandlerResponse, _latency: Duration) {}
+}

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,0 +1,5 @@
+mod middleware;
+mod metrics;
+
+pub use middleware::Middleware;
+pub use metrics::MetricsMiddleware;

--- a/tests/middleware_tests.rs
+++ b/tests/middleware_tests.rs
@@ -1,0 +1,30 @@
+use brrtrouter::{
+    dispatcher::Dispatcher,
+    middleware::MetricsMiddleware,
+    router::Router,
+    load_spec,
+};
+use http::Method;
+use pet_store::registry;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[test]
+fn test_metrics_middleware_counts() {
+    let (routes, _slug) = load_spec("examples/openapi.yaml").unwrap();
+    let router = Router::new(routes.clone());
+    let mut dispatcher = Dispatcher::new();
+    unsafe {
+        registry::register_from_spec(&mut dispatcher, &routes);
+    }
+    let metrics = Arc::new(MetricsMiddleware::new());
+    dispatcher.add_middleware(metrics.clone());
+
+    let route_match = router.route(Method::GET, "/pets/12345").unwrap();
+    let resp = dispatcher
+        .dispatch(route_match, None, HashMap::new(), HashMap::new())
+        .unwrap();
+    assert_eq!(resp.status, 200);
+    assert_eq!(metrics.request_count(), 1);
+    assert!(metrics.average_latency().as_nanos() > 0);
+}


### PR DESCRIPTION
## Summary
- add `Middleware` trait
- implement `MetricsMiddleware`
- update dispatcher to run middleware hooks
- document middleware usage
- test metrics middleware

## Testing
- `cargo test --quiet`