### PR TITLE
Add BRRTR_STACK_SIZE env configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ curl "http://localhost:8080/items/123?debug=true" \
 }
 ```
 
+### Environment Variables
+
+BRRTRouter reads `BRRTR_STACK_SIZE` to determine the stack size for
+coroutines. The value can be a decimal number or a hex string like `0x8000`.
+If unset, the default stack size is `0x4000` bytes.
+
 ## 🏗 Building the Pet Store Example
 Run:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,22 @@ use std::collections::HashMap;
 use may_minihttp::HttpServer;
 use std::io;
 
+fn parse_stack_size() -> usize {
+    if let Ok(val) = std::env::var("BRRTR_STACK_SIZE") {
+        if let Some(hex) = val.strip_prefix("0x") {
+            usize::from_str_radix(hex, 16).unwrap_or(0x4000)
+        } else {
+            val.parse().unwrap_or(0x4000)
+        }
+    } else {
+        0x4000
+    }
+}
+
 fn main() -> io::Result<()> {
     // increase coroutine stack size to prevent overflows
-    may::config().set_stack_size(0x8000);
+    let stack_size = parse_stack_size();
+    may::config().set_stack_size(stack_size);
     // Load OpenAPI spec and create router
     let (routes, _slug) = load_spec("examples/openapi.yaml").expect("failed to load spec");
     let router = Router::new(routes.clone());

--- a/templates/main.rs.txt
+++ b/templates/main.rs.txt
@@ -9,9 +9,22 @@ use {{ name }}::registry;
 use may_minihttp::HttpServer;
 use std::io;
 
+fn parse_stack_size() -> usize {
+    if let Ok(val) = std::env::var("BRRTR_STACK_SIZE") {
+        if let Some(hex) = val.strip_prefix("0x") {
+            usize::from_str_radix(hex, 16).unwrap_or(0x4000)
+        } else {
+            val.parse().unwrap_or(0x4000)
+        }
+    } else {
+        0x4000
+    }
+}
+
 fn main() -> io::Result<()> {
     // enlarge stack size for may coroutines
-    may::config().set_stack_size(0x8000);
+    let stack_size = parse_stack_size();
+    may::config().set_stack_size(stack_size);
     // Load OpenAPI spec and create router
     let (routes, _slug) = brrtrouter::spec::load_spec("./openapi.yaml").expect("failed to load OpenAPI spec");
     let router = Router::new(routes.clone());

--- a/tests/dispatcher_tests.rs
+++ b/tests/dispatcher_tests.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 
 fn set_stack_size() {
+    std::env::set_var("BRRTR_STACK_SIZE", "0x8000");
     may::config().set_stack_size(0x8000);
 }
 

--- a/tests/security_tests.rs
+++ b/tests/security_tests.rs
@@ -50,6 +50,7 @@ fn write_temp(content: &str) -> std::path::PathBuf {
 
 fn start_service() -> (may::coroutine::JoinHandle<()>, SocketAddr) {
     // ensure coroutines have enough stack for tests
+    std::env::set_var("BRRTR_STACK_SIZE", "0x8000");
     may::config().set_stack_size(0x8000);
     const SPEC: &str = r#"openapi: 3.1.0
 info:
@@ -91,6 +92,7 @@ paths:
 
 fn start_multi_service() -> (may::coroutine::JoinHandle<()>, SocketAddr) {
     // ensure coroutines have enough stack for tests
+    std::env::set_var("BRRTR_STACK_SIZE", "0x8000");
     may::config().set_stack_size(0x8000);
     const SPEC: &str = r#"openapi: 3.1.0
 info:

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 
 fn start_petstore_service() -> (may::coroutine::JoinHandle<()>, SocketAddr) {
     // ensure coroutines have enough stack for tests
+    std::env::set_var("BRRTR_STACK_SIZE", "0x8000");
     may::config().set_stack_size(0x8000);
     let (routes, _slug) = brrtrouter::load_spec("examples/openapi.yaml").unwrap();
     let router = Arc::new(RwLock::new(Router::new(routes.clone())));
@@ -112,6 +113,7 @@ fn test_route_404() {
 #[test]
 #[ignore]
 fn test_panic_recovery() {
+    std::env::set_var("BRRTR_STACK_SIZE", "0x8000");
     may::config().set_stack_size(0x8000);
     fn panic_handler(_req: HandlerRequest) {
         panic!("boom");
@@ -152,6 +154,7 @@ fn test_panic_recovery() {
 
 #[test]
 fn test_headers_and_cookies() {
+    std::env::set_var("BRRTR_STACK_SIZE", "0x8000");
     may::config().set_stack_size(0x8000);
     fn header_handler(req: HandlerRequest) {
         let response = HandlerResponse {
@@ -211,6 +214,7 @@ fn test_headers_and_cookies() {
 
 #[test]
 fn test_status_201_json() {
+    std::env::set_var("BRRTR_STACK_SIZE", "0x8000");
     may::config().set_stack_size(0x8000);
     fn create_handler(req: HandlerRequest) {
         let response = HandlerResponse {
@@ -258,6 +262,7 @@ fn test_status_201_json() {
 
 #[test]
 fn test_text_plain_error() {
+    std::env::set_var("BRRTR_STACK_SIZE", "0x8000");
     may::config().set_stack_size(0x8000);
     fn text_handler(req: HandlerRequest) {
         let response = HandlerResponse {

--- a/tests/sse_tests.rs
+++ b/tests/sse_tests.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 fn start_service() -> (may::coroutine::JoinHandle<()>, SocketAddr) {
+    std::env::set_var("BRRTR_STACK_SIZE", "0x8000");
     may::config().set_stack_size(0x8000);
     let (routes, _slug) = brrtrouter::load_spec("examples/openapi.yaml").unwrap();
     let router = Arc::new(RwLock::new(Router::new(routes.clone())));


### PR DESCRIPTION
## Summary
- allow stack size override via `BRRTR_STACK_SIZE` in main binary and template
- set the variable in tests where stack size is configured
- document the variable in the README

## Testing
- `cargo test -q`