### PR TITLE
Extend middleware framework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ url = "2.5.4"
 clap = { version = "4.5.38", features = ["cargo", "env", "derive"] }
 askama = { version = "0.14.0", features = ["full"] }
 notify = "6"
+tracing = "0.1"
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/README.md
+++ b/README.md
@@ -152,15 +152,21 @@ Each handler runs in its own coroutine, receiving requests via a channel and sen
 Middlewares run before and after each handler. Register them on the dispatcher:
 
 ```rust
-use brrrouter::middleware::MetricsMiddleware;
+use brrrouter::middleware::{
+    AuthMiddleware, CorsMiddleware, MetricsMiddleware, TracingMiddleware,
+};
 use std::sync::Arc;
 
 let mut dispatcher = Dispatcher::new();
-let metrics = Arc::new(MetricsMiddleware::new());
-dispatcher.add_middleware(metrics.clone());
+dispatcher.add_middleware(Arc::new(MetricsMiddleware::new()));
+dispatcher.add_middleware(Arc::new(TracingMiddleware));
+dispatcher.add_middleware(Arc::new(AuthMiddleware::new("Bearer secret".into())));
+dispatcher.add_middleware(Arc::new(CorsMiddleware));
 ```
 
-`MetricsMiddleware` tracks request counts and average latency.
+`MetricsMiddleware` tracks request counts and average latency. `TracingMiddleware`
+creates spans for each request, `AuthMiddleware` performs a simple header token
+check, and `CorsMiddleware` adds CORS headers to responses.
 
 ---
 ## 📡 Server-Sent Events

--- a/examples/pet_store/Cargo.toml
+++ b/examples/pet_store/Cargo.toml
@@ -12,3 +12,4 @@ http = "1.0"  # Do not update to newer version, it that is not compatible with m
 may = "0.3"
 may_minihttp = "0.1"
 anyhow = "1.0"
+tracing = "0.1"

--- a/examples/pet_store/src/main.rs
+++ b/examples/pet_store/src/main.rs
@@ -1,6 +1,7 @@
 
 use brrtrouter::{
     dispatcher::Dispatcher,
+    middleware::{AuthMiddleware, CorsMiddleware, MetricsMiddleware, TracingMiddleware},
     router::Router,
     server::AppService,
 };
@@ -29,17 +30,25 @@ fn main() -> io::Result<()> {
     let (routes, _slug) = brrtrouter::spec::load_spec("./openapi.yaml").expect("failed to load OpenAPI spec");
     let router = Router::new(routes.clone());
 
-    // Create dispatcher and register handlers
+    // Create dispatcher, register handlers, and stack middlewares
     let mut dispatcher = Dispatcher::new();
     unsafe {
         registry::register_from_spec(&mut dispatcher, &routes);
     }
+    let metrics = std::sync::Arc::new(MetricsMiddleware::new());
+    let tracing_mw = std::sync::Arc::new(TracingMiddleware);
+    let auth = std::sync::Arc::new(AuthMiddleware::new("Bearer secret".into()));
+    let cors = std::sync::Arc::new(CorsMiddleware);
+    dispatcher.add_middleware(metrics);
+    dispatcher.add_middleware(tracing_mw);
+    dispatcher.add_middleware(auth);
+    dispatcher.add_middleware(cors);
 
     // Start the HTTP server on port 8080, binding to 127.0.0.1 if BRRTR_LOCAL is
     // set for local testing.
     // This returns a coroutine JoinHandle; we join on it to keep the server running
-    let router = std::sync::Arc::new(std::sync::RwLock::new(Router::new(routes)));
-    let dispatcher = std::sync::Arc::new(std::sync::RwLock::new(Dispatcher::new()));
+    let router = std::sync::Arc::new(std::sync::RwLock::new(router));
+    let dispatcher = std::sync::Arc::new(std::sync::RwLock::new(dispatcher));
     let service = AppService::new(router, dispatcher, HashMap::new());
     let addr = if std::env::var("BRRTR_LOCAL").is_ok() {
         "127.0.0.1:8080"

--- a/src/echo.rs
+++ b/src/echo.rs
@@ -1,4 +1,5 @@
 use crate::dispatcher::{HandlerRequest, HandlerResponse};
+use std::collections::HashMap;
 
 // Example handler: just echoes back input for now
 // This handler is useful for testing and debugging purposes.
@@ -6,6 +7,7 @@ use crate::dispatcher::{HandlerRequest, HandlerResponse};
 pub fn echo_handler(req: HandlerRequest) {
     let response = HandlerResponse {
         status: 200,
+        headers: HashMap::new(),
         body: serde_json::json!({
             "handler": req.handler_name,
             "method": req.method.to_string(),

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -1,0 +1,31 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use super::Middleware;
+use crate::dispatcher::{HandlerRequest, HandlerResponse};
+
+pub struct AuthMiddleware {
+    token: String,
+}
+
+impl AuthMiddleware {
+    pub fn new(token: String) -> Self {
+        Self { token }
+    }
+}
+
+impl Middleware for AuthMiddleware {
+    fn before(&self, req: &HandlerRequest) -> Option<HandlerResponse> {
+        match req.headers.get("authorization") {
+            Some(h) if h == &self.token => None,
+            _ => Some(HandlerResponse {
+                status: 401,
+                headers: HashMap::new(),
+                body: serde_json::json!({ "error": "Unauthorized" }),
+            }),
+        }
+    }
+
+    fn after(&self, _req: &HandlerRequest, _res: &mut HandlerResponse, _latency: Duration) {}
+}
+

--- a/src/middleware/cors.rs
+++ b/src/middleware/cors.rs
@@ -1,0 +1,21 @@
+use std::time::Duration;
+
+use super::Middleware;
+use crate::dispatcher::{HandlerRequest, HandlerResponse};
+
+pub struct CorsMiddleware;
+
+impl Middleware for CorsMiddleware {
+    fn after(&self, _req: &HandlerRequest, res: &mut HandlerResponse, _latency: Duration) {
+        res.headers.insert("Access-Control-Allow-Origin".into(), "*".into());
+        res.headers.insert(
+            "Access-Control-Allow-Headers".into(),
+            "Content-Type, Authorization".into(),
+        );
+        res.headers.insert(
+            "Access-Control-Allow-Methods".into(),
+            "GET, POST, PUT, DELETE, OPTIONS".into(),
+        );
+    }
+}
+

--- a/src/middleware/metrics.rs
+++ b/src/middleware/metrics.rs
@@ -43,11 +43,12 @@ impl MetricsMiddleware {
 }
 
 impl Middleware for MetricsMiddleware {
-    fn before(&self, _req: &HandlerRequest) {
+    fn before(&self, _req: &HandlerRequest) -> Option<HandlerResponse> {
         self.request_count.fetch_add(1, Ordering::Relaxed);
+        None
     }
 
-    fn after(&self, _req: &HandlerRequest, _res: &HandlerResponse, latency: Duration) {
+    fn after(&self, _req: &HandlerRequest, _res: &mut HandlerResponse, latency: Duration) {
         self.total_latency_ns
             .fetch_add(latency.as_nanos() as u64, Ordering::Relaxed);
         // record stack metrics for the current coroutine when available

--- a/src/middleware/middleware.rs
+++ b/src/middleware/middleware.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 use crate::dispatcher::{HandlerRequest, HandlerResponse};
 
 pub trait Middleware: Send + Sync {
-    fn before(&self, _req: &HandlerRequest) {}
-    fn after(&self, _req: &HandlerRequest, _res: &HandlerResponse, _latency: Duration) {}
+    fn before(&self, _req: &HandlerRequest) -> Option<HandlerResponse> {
+        None
+    }
+    fn after(&self, _req: &HandlerRequest, _res: &mut HandlerResponse, _latency: Duration) {}
 }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,5 +1,11 @@
 mod middleware;
 mod metrics;
+mod tracing;
+mod auth;
+mod cors;
 
 pub use middleware::Middleware;
 pub use metrics::MetricsMiddleware;
+pub use tracing::TracingMiddleware;
+pub use auth::AuthMiddleware;
+pub use cors::CorsMiddleware;

--- a/src/middleware/tracing.rs
+++ b/src/middleware/tracing.rs
@@ -1,0 +1,37 @@
+use std::cell::RefCell;
+use std::time::Duration;
+
+use tracing::{info_span, span::EnteredSpan, Span};
+
+use super::Middleware;
+use crate::dispatcher::{HandlerRequest, HandlerResponse};
+
+thread_local! {
+    static SPAN_GUARD: RefCell<Option<(Span, EnteredSpan)>> = RefCell::new(None);
+}
+
+pub struct TracingMiddleware;
+
+impl Middleware for TracingMiddleware {
+    fn before(&self, req: &HandlerRequest) -> Option<HandlerResponse> {
+        let span = info_span!(
+            "request",
+            method = ?req.method,
+            path = %req.path,
+            handler = %req.handler_name
+        );
+        let guard = span.enter();
+        SPAN_GUARD.with(|g| *g.borrow_mut() = Some((span, guard)));
+        None
+    }
+
+    fn after(&self, _req: &HandlerRequest, res: &mut HandlerResponse, latency: Duration) {
+        SPAN_GUARD.with(|g| {
+            if let Some((span, _guard)) = g.borrow_mut().take() {
+                span.record("status", &res.status);
+                span.record("latency_ms", &(latency.as_millis() as u64));
+            }
+        });
+    }
+}
+

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -13,9 +13,20 @@ fn status_reason(status: u16) -> &'static str {
     }
 }
 
-pub fn write_handler_response(res: &mut Response, status: u16, body: Value, is_sse: bool) {
+use std::collections::HashMap;
+
+pub fn write_handler_response(
+    res: &mut Response,
+    status: u16,
+    body: Value,
+    is_sse: bool,
+    headers: &HashMap<String, String>,
+) {
     let reason = status_reason(status);
     res.status_code(status as usize, reason);
+    for (k, v) in headers {
+        res.header(&format!("{}: {}", k, v));
+    }
     match body {
         Value::String(s) => {
             if is_sse {

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -100,8 +100,8 @@ impl HttpService for AppService {
                 dispatcher.dispatch(route_match, body, headers, cookies)
             };
             match handler_response {
-                Some(HandlerResponse { status, body }) => {
-                    write_handler_response(res, status, body, is_sse);
+                Some(mut hr) => {
+                    write_handler_response(res, hr.status, hr.body, is_sse, &hr.headers);
                 }
                 None => {
                     write_json_error(

--- a/src/typed/typed.rs
+++ b/src/typed/typed.rs
@@ -42,6 +42,7 @@ where
                 Err(err) => {
                     let _ = reply_tx.send(HandlerResponse {
                         status: 400,
+                        headers: HashMap::new(),
                         body: serde_json::json!({
                             "error": "Invalid request data",
                             "message": err.to_string()
@@ -64,9 +65,10 @@ where
 
             let _ = reply_tx.send(HandlerResponse {
                 status: 200,
-                body: serde_json::to_value(result).unwrap_or_else(
-                    |_| serde_json::json!({"error": "Failed to serialize response"}),
-                ),
+                headers: HashMap::new(),
+                body: serde_json::to_value(result).unwrap_or_else(|_| {
+                    serde_json::json!({"error": "Failed to serialize response"})
+                }),
             });
         }
     })

--- a/tests/security_tests.rs
+++ b/tests/security_tests.rs
@@ -7,6 +7,7 @@ use brrtrouter::{
 };
 use may_minihttp::HttpServer;
 use serde_json::json;
+use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::{Arc, RwLock};
@@ -77,7 +78,11 @@ paths:
     let mut dispatcher = Dispatcher::new();
     unsafe {
         dispatcher.register_handler("secret", |req: HandlerRequest| {
-            let _ = req.reply_tx.send(HandlerResponse { status: 200, body: json!({"ok": true}) });
+            let _ = req.reply_tx.send(HandlerResponse {
+                status: 200,
+                headers: HashMap::new(),
+                body: json!({"ok": true}),
+            });
         });
     }
     let mut service = AppService::new(router, Arc::new(RwLock::new(dispatcher)), schemes);
@@ -130,14 +135,18 @@ paths:
     let mut dispatcher = Dispatcher::new();
     unsafe {
         dispatcher.register_handler("one", |req: HandlerRequest| {
-            let _ = req
-                .reply_tx
-                .send(HandlerResponse { status: 200, body: json!({"one": true}) });
+            let _ = req.reply_tx.send(HandlerResponse {
+                status: 200,
+                headers: HashMap::new(),
+                body: json!({"one": true}),
+            });
         });
         dispatcher.register_handler("two", |req: HandlerRequest| {
-            let _ = req
-                .reply_tx
-                .send(HandlerResponse { status: 200, body: json!({"two": true}) });
+            let _ = req.reply_tx.send(HandlerResponse {
+                status: 200,
+                headers: HashMap::new(),
+                body: json!({"two": true}),
+            });
         });
     }
     let mut service = AppService::new(router, Arc::new(RwLock::new(dispatcher)), schemes);

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -159,6 +159,7 @@ fn test_headers_and_cookies() {
     fn header_handler(req: HandlerRequest) {
         let response = HandlerResponse {
             status: 200,
+            headers: HashMap::new(),
             body: json!({
                 "headers": req.headers,
                 "cookies": req.cookies,
@@ -219,6 +220,7 @@ fn test_status_201_json() {
     fn create_handler(req: HandlerRequest) {
         let response = HandlerResponse {
             status: 201,
+            headers: HashMap::new(),
             body: json!({"created": true}),
         };
         let _ = req.reply_tx.send(response);
@@ -267,6 +269,7 @@ fn test_text_plain_error() {
     fn text_handler(req: HandlerRequest) {
         let response = HandlerResponse {
             status: 400,
+            headers: HashMap::new(),
             body: json!("bad request"),
         };
         let _ = req.reply_tx.send(response);


### PR DESCRIPTION
## Summary
- extend middleware trait to allow short-circuiting and response mutation
- add tracing, auth and CORS middleware implementations
- expose new middleware in the API and document usage
- update dispatcher to support early responses and headers
- add headers field to `HandlerResponse`
- demonstrate middleware stacking in the pet_store example
- adjust tests for new response structure

## Testing
- `cargo test --locked` *(fails: failed to download crates)*