### PR TITLE
Add SSE tests and streaming example

### DIFF
--- a/examples/pet_store/src/controllers/stream_events.rs
+++ b/examples/pet_store/src/controllers/stream_events.rs
@@ -1,6 +1,7 @@
 // User-owned controller for handler 'stream_events'.
 use crate::brrtrouter::typed::{Handler, TypedHandlerRequest};
 use crate::handlers::stream_events::{Request, Response};
+use crate::brrtrouter::sse;
 
 pub struct StreamEventsController;
 
@@ -8,7 +9,12 @@ impl Handler for StreamEventsController {
     type Request = Request;
     type Response = Response;
     fn handle(&self, _req: TypedHandlerRequest<Request>) -> Response {
-        Response {}
+        let (tx, rx) = sse::channel();
+        for i in 0..3 {
+            tx.send(format!("tick {}", i));
+        }
+        drop(tx);
+        Response(rx.collect())
     }
 }
 

--- a/examples/pet_store/src/handlers/stream_events.rs
+++ b/examples/pet_store/src/handlers/stream_events.rs
@@ -8,8 +8,9 @@ use std::convert::TryFrom;
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Request {}
 
+/// SSE responses are represented as raw event strings.
 #[derive(Debug, Serialize)]
-pub struct Response {}
+pub struct Response(pub String);
 
 impl TryFrom<HandlerRequest> for Request {
     type Error = anyhow::Error;

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -54,10 +54,114 @@ pub fn write_json_error(res: &mut Response, status: u16, body: Value) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use may_minihttp::{HttpServer, HttpService, Request, Response};
+    use std::collections::HashMap;
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::time::Duration;
+
+    #[derive(Clone)]
+    struct HandlerService;
+
+    impl HttpService for HandlerService {
+        fn call(&mut self, _req: Request, res: &mut Response) -> std::io::Result<()> {
+            let mut headers = HashMap::new();
+            headers.insert("X-Test".to_string(), "foo".to_string());
+            write_handler_response(res, 201, serde_json::json!({"ok": true}), false, &headers);
+            Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct ErrorService;
+
+    impl HttpService for ErrorService {
+        fn call(&mut self, _req: Request, res: &mut Response) -> std::io::Result<()> {
+            write_json_error(res, 404, serde_json::json!({"error": "nope"}));
+            Ok(())
+        }
+    }
+
+    fn send_request(addr: &std::net::SocketAddr, req: &str) -> String {
+        let mut stream = TcpStream::connect(addr).unwrap();
+        stream.write_all(req.as_bytes()).unwrap();
+        stream.set_read_timeout(Some(Duration::from_millis(100))).unwrap();
+        let mut buf = Vec::new();
+        loop {
+            let mut tmp = [0u8; 1024];
+            match stream.read(&mut tmp) {
+                Ok(0) => break,
+                Ok(n) => buf.extend_from_slice(&tmp[..n]),
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock || e.kind() == std::io::ErrorKind::TimedOut => break,
+                Err(e) => panic!("read error: {:?}", e),
+            }
+        }
+        String::from_utf8_lossy(&buf).to_string()
+    }
+
+    fn parse_parts(resp: &str) -> (u16, String, String) {
+        let mut parts = resp.split("\r\n\r\n");
+        let headers = parts.next().unwrap_or("");
+        let body = parts.next().unwrap_or("").to_string();
+        let mut status = 0;
+        let mut ct = String::new();
+        let mut x_test = false;
+        for line in headers.lines() {
+            if line.starts_with("HTTP/1.1") {
+                status = line
+                    .split_whitespace()
+                    .nth(1)
+                    .unwrap_or("0")
+                    .parse()
+                    .unwrap();
+            } else if let Some((n, v)) = line.split_once(':') {
+                if n.eq_ignore_ascii_case("content-type") {
+                    ct = v.trim().to_string();
+                } else if n.eq_ignore_ascii_case("x-test") {
+                    x_test = true;
+                }
+            }
+        }
+        let info = if x_test {
+            format!("{}|X-Test", ct)
+        } else {
+            ct
+        };
+        (status, info, body)
+    }
 
     #[test]
     fn test_status_reason() {
         assert_eq!(status_reason(200), "OK");
         assert_eq!(status_reason(404), "Not Found");
+    }
+
+    #[test]
+    fn test_write_handler_response() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let handle = HttpServer(HandlerService).start(addr).unwrap();
+        let resp = send_request(&addr, "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        unsafe { handle.coroutine().cancel() };
+        let (status, info, body) = parse_parts(&resp);
+        assert_eq!(status, 201);
+        assert!(info.starts_with("application/json"));
+        assert!(info.contains("X-Test"));
+        assert_eq!(body, "{\"ok\":true}");
+    }
+
+    #[test]
+    fn test_write_json_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let handle = HttpServer(ErrorService).start(addr).unwrap();
+        let resp = send_request(&addr, "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        unsafe { handle.coroutine().cancel() };
+        let (status, ct, body) = parse_parts(&resp);
+        assert_eq!(status, 404);
+        assert_eq!(ct, "application/json");
+        assert_eq!(body, "{\"error\":\"nope\"}");
     }
 }

--- a/tests/sse_tests.rs
+++ b/tests/sse_tests.rs
@@ -87,7 +87,6 @@ fn parse_parts(resp: &str) -> (u16, String, String) {
 }
 
 #[test]
-#[ignore]
 fn test_event_stream() {
     let (_tracing, handle, addr) = start_service();
     let resp = send_request(&addr, "GET /events HTTP/1.1\r\nHost: localhost\r\n\r\n");
@@ -95,6 +94,10 @@ fn test_event_stream() {
     let (status, ct, body) = parse_parts(&resp);
     assert_eq!(status, 200);
     assert_eq!(ct, "text/event-stream");
-    assert!(body.contains("data: tick 0"));
-    assert!(body.contains("data: tick 2"));
+    let events: Vec<_> = body
+        .lines()
+        .filter(|l| l.starts_with("data: "))
+        .map(|l| l[6..].trim())
+        .collect();
+    assert_eq!(events, ["tick 0", "tick 1", "tick 2"]);
 }


### PR DESCRIPTION
## Summary
- add an SSE example controller that emits events
- represent SSE handler responses as strings
- test HTTP response helpers
- verify SSE streaming test

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68398f89a968832f8faa9e9350729d51