### PR TITLE
Recover typed handler panics

### DIFF
--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -120,9 +120,7 @@ fn test_route_404() {
     assert_eq!(status, 404);
 }
 
-// TODO: fix this test, its mean't to test panics, but the test or code does not correctly recover from a panic
 #[test]
-#[ignore]
 fn test_panic_recovery() {
     may::config().set_stack_size(0x8000);
     let _tracing = TestTracing::init();


### PR DESCRIPTION
## Summary
- catch panics in `spawn_typed` request loop
- send a 500 error on panic and log details
- enable `test_panic_recovery` to assert 500 status

## Testing
- `cargo test test_panic_recovery -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_683a3c35beec832f91943b2932395a1e