### PR TITLE
Add directory traversal tests for StaticFiles

### DIFF
--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -85,6 +85,7 @@ mod tests {
         let sf = StaticFiles::new("tests/staticdata");
         assert!(sf.map_path("../Cargo.toml").is_none());
         let escaped_string = "..\\/..\\/Cargo.toml";
+        assert!(sf.map_path(escaped_string).is_none());
     }
 
     #[test]

--- a/tests/static_files_tests.rs
+++ b/tests/static_files_tests.rs
@@ -17,4 +17,5 @@ fn test_html_rendering() {
 fn test_traversal_prevented() {
     let sf = StaticFiles::new("tests/staticdata");
     assert!(sf.load("../Cargo.toml", None).is_err());
+    assert!(sf.load("..\\Cargo.toml", None).is_err());
 }


### PR DESCRIPTION
## Summary
- verify path mapping rejects Windows-style traversal
- add assertion in unit test for path traversal

## Testing
- `cargo test --test static_files_tests -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_683a40dfb558832fa89161f6f80a0c64