### PR TITLE
Add flamegraph profiling tools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ opentelemetry = "0.29.1"
 pet_store = { path = "./examples/pet_store" }
 criterion = "0.5"
 fake-opentelemetry-collector = "0.28"
+flamegraph = "0.6"
 
 [[bin]]
 name = "brrtrouter-gen"

--- a/README.md
+++ b/README.md
@@ -161,6 +161,26 @@ allocations as hotspots. Preallocating buffers in `Router::route` and
 `path_to_regex` trimmed roughly 5% off benchmark times on the expanded
 throughput suite.
 
+### 🔥 Generating Flamegraphs
+
+Install the `cargo-flamegraph` subcommand by adding it as a development
+dependency:
+
+```toml
+[dev-dependencies]
+flamegraph = "0.6"
+```
+
+Run the profiler against the pet store example:
+
+```bash
+just flamegraph
+```
+
+The command produces `flamegraph.svg` in `target/flamegraphs/`. Open the file in
+your browser to inspect hot code paths.
+See [docs/flamegraph.md](docs/flamegraph.md) for tips on reading the output.
+
 
 
 

--- a/docs/flamegraph.md
+++ b/docs/flamegraph.md
@@ -1,0 +1,11 @@
+# Interpreting Flamegraphs
+
+Flamegraphs visualize CPU usage over time. Each bar represents a function call; wider bars consumed more CPU during the profiling run.
+
+- **X-axis** – stack traces sorted by time spent. The width shows how much of the sample period was spent in that call stack.
+- **Y-axis** – call depth. Parents call the functions above them.
+- **Hot spots** – the widest blocks near the bottom are typically the most expensive code paths.
+
+Use your browser's search to find functions of interest. Hovering over a block displays its percentage of total CPU time.
+
+To reduce noise, run profiling in release mode and try to exercise the workload you care about before stopping `cargo flamegraph`.

--- a/justfile
+++ b/justfile
@@ -23,3 +23,7 @@ coverage:
 # Run benchmarks
 bench:
     cargo bench
+
+# Profile the example server with cargo flamegraph
+flamegraph:
+    cargo flamegraph -p pet_store --bin pet_store


### PR DESCRIPTION
## Summary
- add `flamegraph` to dev dependencies
- document how to profile with `cargo flamegraph`
- add `just` recipe for running flamegraph
- document how to read flamegraphs

## Testing
- `cargo generate-lockfile` *(fails: Could not connect to server)*
- `cargo test --no-run` *(fails: failed to get `anyhow` as a dependency)*


------
https://chatgpt.com/codex/tasks/task_e_683a43204ed4832f880a1f517fb1c9b4