### PR TITLE
Add static file serving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2088,6 +2088,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "brrtrouter",
+ "clap",
  "http 1.3.1",
  "may",
  "may_minihttp",

--- a/examples/pet_store/Cargo.toml
+++ b/examples/pet_store/Cargo.toml
@@ -12,3 +12,4 @@ http = "1.0"  # Do not update to newer version, it that is not compatible with m
 may = "0.3"
 may_minihttp = "0.1"
 anyhow = "1.0"
+clap = { version = "4.5.39", features = ["derive"] }

--- a/templates/Cargo.toml.txt
+++ b/templates/Cargo.toml.txt
@@ -12,3 +12,4 @@ http = "1.0"  # Do not update to newer version, it that is not compatible with m
 may = "0.3"
 may_minihttp = "0.1"
 anyhow = "1.0"
+clap = { version = "4.5.39", features = ["derive"] }

--- a/templates/main.rs.txt
+++ b/templates/main.rs.txt
@@ -1,15 +1,11 @@
 {# templates/main.rs.txt #}
-use brrtrouter::{
-    dispatcher::Dispatcher,
-    router::Router,
-    server::AppService,
-};
-use clap::Parser;
-use std::collections::HashMap;
-use std::path::PathBuf;
-use {{ name }}::registry;
 use brrtrouter::server::HttpServer;
+use brrtrouter::{dispatcher::Dispatcher, router::Router, server::AppService};
+use clap::Parser;
+use {{ name }}::registry;
+use std::collections::HashMap;
 use std::io;
+use std::path::PathBuf;
 
 fn parse_stack_size() -> usize {
     if let Ok(val) = std::env::var("BRRTR_STACK_SIZE") {
@@ -37,7 +33,8 @@ fn main() -> io::Result<()> {
     let stack_size = parse_stack_size();
     may::config().set_stack_size(stack_size);
     // Load OpenAPI spec and create router
-    let (routes, _slug) = brrtrouter::spec::load_spec(args.spec.to_str().unwrap()).expect("failed to load OpenAPI spec");
+    let (routes, _slug) = brrtrouter::spec::load_spec(args.spec.to_str().unwrap())
+        .expect("failed to load OpenAPI spec");
     let router = Router::new(routes.clone());
 
     // Create dispatcher and register handlers
@@ -64,9 +61,7 @@ fn main() -> io::Result<()> {
         "0.0.0.0:8080"
     };
     println!("🚀 {{ name }} example server listening on {addr}");
-    let server = HttpServer(service)
-        .start(addr)
-        .map_err(io::Error::other)?;
+    let server = HttpServer(service).start(addr).map_err(io::Error::other)?;
     println!("Server started successfully on {addr}");
 
     server

--- a/templates/main.rs.txt
+++ b/templates/main.rs.txt
@@ -4,6 +4,7 @@ use brrtrouter::{
     router::Router,
     server::AppService,
 };
+use clap::Parser;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use {{ name }}::registry;
@@ -22,12 +23,21 @@ fn parse_stack_size() -> usize {
     }
 }
 
+#[derive(Parser)]
+struct Args {
+    #[arg(short, long, default_value = "./openapi.yaml")]
+    spec: PathBuf,
+    #[arg(long)]
+    static_dir: Option<PathBuf>,
+}
+
 fn main() -> io::Result<()> {
     // enlarge stack size for may coroutines
+    let args = Args::parse();
     let stack_size = parse_stack_size();
     may::config().set_stack_size(stack_size);
     // Load OpenAPI spec and create router
-    let (routes, _slug) = brrtrouter::spec::load_spec("./openapi.yaml").expect("failed to load OpenAPI spec");
+    let (routes, _slug) = brrtrouter::spec::load_spec(args.spec.to_str().unwrap()).expect("failed to load OpenAPI spec");
     let router = Router::new(routes.clone());
 
     // Create dispatcher and register handlers
@@ -45,7 +55,8 @@ fn main() -> io::Result<()> {
         router,
         dispatcher,
         HashMap::new(),
-        PathBuf::from("./openapi.yaml"),
+        args.spec.clone(),
+        args.static_dir.clone(),
     );
     let addr = if std::env::var("BRRTR_LOCAL").is_ok() {
         "127.0.0.1:8080"

--- a/tests/docs_endpoint_tests.rs
+++ b/tests/docs_endpoint_tests.rs
@@ -28,6 +28,7 @@ fn start_service() -> (TestTracing, ServerHandle, SocketAddr) {
         Arc::new(RwLock::new(dispatcher)),
         HashMap::new(),
         PathBuf::from("examples/openapi.yaml"),
+        None,
     );
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();

--- a/tests/metrics_endpoint_tests.rs
+++ b/tests/metrics_endpoint_tests.rs
@@ -34,6 +34,7 @@ fn start_service() -> (TestTracing, ServerHandle, SocketAddr) {
         Arc::new(RwLock::new(dispatcher)),
         HashMap::new(),
         PathBuf::from("examples/openapi.yaml"),
+        None,
     );
     service.set_metrics_middleware(metrics);
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();

--- a/tests/multi_response_tests.rs
+++ b/tests/multi_response_tests.rs
@@ -109,6 +109,7 @@ fn test_select_content_type_from_spec() {
         Arc::new(RwLock::new(dispatcher)),
         HashMap::new(),
         PathBuf::new(),
+        None,
     );
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();

--- a/tests/security_tests.rs
+++ b/tests/security_tests.rs
@@ -95,6 +95,7 @@ paths:
         Arc::new(RwLock::new(dispatcher)),
         schemes,
         PathBuf::from("examples/openapi.yaml"),
+        None,
     );
     service.register_security_provider(
         "ApiKeyAuth",
@@ -172,6 +173,7 @@ paths:
         Arc::new(RwLock::new(dispatcher)),
         schemes,
         PathBuf::from("examples/openapi.yaml"),
+        None,
     );
     service.register_security_provider("KeyOne", Arc::new(ApiKeyProvider { key: "one".into() }));
     service.register_security_provider("KeyTwo", Arc::new(ApiKeyProvider { key: "two".into() }));
@@ -244,6 +246,7 @@ paths:
         Arc::new(RwLock::new(dispatcher)),
         schemes,
         PathBuf::from("examples/openapi.yaml"),
+        None,
     );
     service.register_security_provider("BearerAuth", Arc::new(BearerJwtProvider::new("sig")));
     service.register_security_provider(

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -35,6 +35,7 @@ fn start_petstore_service() -> (TestTracing, ServerHandle, SocketAddr) {
         Arc::new(RwLock::new(dispatcher)),
         HashMap::new(),
         PathBuf::from("examples/openapi.yaml"),
+        None,
     );
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
@@ -154,6 +155,7 @@ fn test_panic_recovery() {
         Arc::new(RwLock::new(dispatcher)),
         HashMap::new(),
         PathBuf::from("examples/openapi.yaml"),
+        None,
     );
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
@@ -210,6 +212,7 @@ fn test_headers_and_cookies() {
         Arc::new(RwLock::new(dispatcher)),
         HashMap::new(),
         PathBuf::from("examples/openapi.yaml"),
+        None,
     );
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
@@ -274,6 +277,7 @@ fn test_status_201_json() {
         Arc::new(RwLock::new(dispatcher)),
         HashMap::new(),
         PathBuf::from("examples/openapi.yaml"),
+        None,
     );
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
@@ -329,6 +333,7 @@ fn test_text_plain_error() {
         Arc::new(RwLock::new(dispatcher)),
         HashMap::new(),
         PathBuf::from("examples/openapi.yaml"),
+        None,
     );
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();

--- a/tests/sse_tests.rs
+++ b/tests/sse_tests.rs
@@ -30,6 +30,7 @@ fn start_service() -> (TestTracing, ServerHandle, SocketAddr) {
         Arc::new(RwLock::new(dispatcher)),
         HashMap::new(),
         PathBuf::from("examples/openapi.yaml"),
+        None,
     );
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();

--- a/tests/static_files_tests.rs
+++ b/tests/static_files_tests.rs
@@ -14,6 +14,14 @@ fn test_html_rendering() {
 }
 
 #[test]
+fn test_js_bundle() {
+    let sf = StaticFiles::new("tests/staticdata");
+    let (bytes, ct) = sf.load("bundle.js", None).unwrap();
+    assert_eq!(ct, "application/javascript");
+    assert_eq!(String::from_utf8(bytes).unwrap(), "console.log('bundled');\n");
+}
+
+#[test]
 fn test_traversal_prevented() {
     let sf = StaticFiles::new("tests/staticdata");
     assert!(sf.load("../Cargo.toml", None).is_err());

--- a/tests/static_server_tests.rs
+++ b/tests/static_server_tests.rs
@@ -8,86 +8,75 @@ use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
-mod tracing_util;
-use brrtrouter::middleware::TracingMiddleware;
-use tracing_util::TestTracing;
-
-fn start_service() -> (TestTracing, ServerHandle, SocketAddr) {
-    // ensure coroutines have enough stack for tests
-    std::env::set_var("BRRTR_STACK_SIZE", "0x8000");
-    may::config().set_stack_size(0x8000);
-    let tracing = TestTracing::init();
+fn start_service() -> (ServerHandle, SocketAddr) {
     let (routes, _slug) = brrtrouter::load_spec("examples/openapi.yaml").unwrap();
     let router = Arc::new(RwLock::new(Router::new(routes.clone())));
     let mut dispatcher = Dispatcher::new();
-    unsafe {
-        registry::register_from_spec(&mut dispatcher, &routes);
-    }
-    dispatcher.add_middleware(Arc::new(TracingMiddleware));
+    unsafe { registry::register_from_spec(&mut dispatcher, &routes); }
     let service = AppService::new(
         router,
         Arc::new(RwLock::new(dispatcher)),
         HashMap::new(),
         PathBuf::from("examples/openapi.yaml"),
-        None,
+        Some(PathBuf::from("tests/staticdata")),
     );
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
     drop(listener);
     let handle = HttpServer(service).start(addr).unwrap();
     handle.wait_ready().unwrap();
-    (tracing, handle, addr)
+    (handle, addr)
 }
 
 fn send_request(addr: &SocketAddr, req: &str) -> String {
     let mut stream = TcpStream::connect(addr).unwrap();
     stream.write_all(req.as_bytes()).unwrap();
-    stream
-        .set_read_timeout(Some(Duration::from_millis(100)))
-        .unwrap();
+    stream.set_read_timeout(Some(Duration::from_millis(100))).unwrap();
     let mut buf = Vec::new();
     loop {
         let mut tmp = [0u8; 1024];
         match stream.read(&mut tmp) {
             Ok(0) => break,
             Ok(n) => buf.extend_from_slice(&tmp[..n]),
-            Err(ref e)
-                if e.kind() == std::io::ErrorKind::WouldBlock
-                    || e.kind() == std::io::ErrorKind::TimedOut =>
-            {
-                break
-            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock || e.kind() == std::io::ErrorKind::TimedOut => break,
             Err(e) => panic!("read error: {:?}", e),
         }
     }
     String::from_utf8_lossy(&buf).to_string()
 }
 
-fn parse_response(resp: &str) -> (u16, serde_json::Value) {
+fn parse_parts(resp: &str) -> (u16, String) {
     let mut parts = resp.split("\r\n\r\n");
     let headers = parts.next().unwrap_or("");
-    let body = parts.next().unwrap_or("");
     let mut status = 0;
+    let mut content_type = String::new();
     for line in headers.lines() {
         if line.starts_with("HTTP/1.1") {
-            status = line
-                .split_whitespace()
-                .nth(1)
-                .unwrap_or("0")
-                .parse()
-                .unwrap();
+            status = line.split_whitespace().nth(1).unwrap_or("0").parse().unwrap();
+        } else if let Some((name, val)) = line.split_once(':') {
+            if name.eq_ignore_ascii_case("content-type") {
+                content_type = val.trim().to_string();
+            }
         }
     }
-    let json: serde_json::Value = serde_json::from_str(body).unwrap_or_default();
-    (status, json)
+    (status, content_type)
 }
 
 #[test]
-fn test_health_endpoint() {
-    let (_tracing, handle, addr) = start_service();
-    let resp = send_request(&addr, "GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n");
+fn test_js_served() {
+    let (handle, addr) = start_service();
+    let resp = send_request(&addr, "GET /bundle.js HTTP/1.1\r\nHost: x\r\n\r\n");
     handle.stop();
-    let (status, body) = parse_response(&resp);
+    let (status, ct) = parse_parts(&resp);
     assert_eq!(status, 200);
-    assert_eq!(body["status"], "ok");
+    assert_eq!(ct, "application/javascript");
+}
+
+#[test]
+fn test_traversal_blocked() {
+    let (handle, addr) = start_service();
+    let resp = send_request(&addr, "GET /../Cargo.toml HTTP/1.1\r\nHost: x\r\n\r\n");
+    handle.stop();
+    let (status, _) = parse_parts(&resp);
+    assert_eq!(status, 404);
 }

--- a/tests/staticdata/bundle.js
+++ b/tests/staticdata/bundle.js
@@ -1,0 +1,1 @@
+console.log('bundled');


### PR DESCRIPTION
## Summary
- implement StaticFiles mapping with backslash detection
- add static file serving option to `AppService`
- support `--static-dir` CLI option in examples and template
- provide JS bundle example and tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683a43006350832fbee300aa4907dae0