### PR TITLE
Fix example route registration

### DIFF
--- a/examples/pet_store/src/main.rs
+++ b/examples/pet_store/src/main.rs
@@ -36,9 +36,8 @@ fn main() -> io::Result<()> {
     // Load OpenAPI spec and create router
     let (routes, _slug) = brrtrouter::spec::load_spec(args.spec.to_str().unwrap())
         .expect("failed to load OpenAPI spec");
+    // Create router and dispatcher
     let router = Router::new(routes.clone());
-
-    // Create dispatcher and register handlers
     let mut dispatcher = Dispatcher::new();
     unsafe {
         registry::register_from_spec(&mut dispatcher, &routes);
@@ -47,8 +46,8 @@ fn main() -> io::Result<()> {
     // Start the HTTP server on port 8080, binding to 127.0.0.1 if BRRTR_LOCAL is
     // set for local testing.
     // This returns a coroutine JoinHandle; we join on it to keep the server running
-    let router = std::sync::Arc::new(std::sync::RwLock::new(Router::new(routes)));
-    let dispatcher = std::sync::Arc::new(std::sync::RwLock::new(Dispatcher::new()));
+    let router = std::sync::Arc::new(std::sync::RwLock::new(router));
+    let dispatcher = std::sync::Arc::new(std::sync::RwLock::new(dispatcher));
     let service = AppService::new(
         router,
         dispatcher,

--- a/templates/main.rs.txt
+++ b/templates/main.rs.txt
@@ -37,9 +37,8 @@ fn main() -> io::Result<()> {
     // Load OpenAPI spec and create router
     let (routes, _slug) = brrtrouter::spec::load_spec(args.spec.to_str().unwrap())
         .expect("failed to load OpenAPI spec");
+    // Create router and dispatcher
     let router = Router::new(routes.clone());
-
-    // Create dispatcher and register handlers
     let mut dispatcher = Dispatcher::new();
     unsafe {
         registry::register_from_spec(&mut dispatcher, &routes);
@@ -48,8 +47,8 @@ fn main() -> io::Result<()> {
     // Start the HTTP server on port 8080, binding to 127.0.0.1 if BRRTR_LOCAL is
     // set for local testing.
     // This returns a coroutine JoinHandle; we join on it to keep the server running
-    let router = std::sync::Arc::new(std::sync::RwLock::new(Router::new(routes)));
-    let dispatcher = std::sync::Arc::new(std::sync::RwLock::new(Dispatcher::new()));
+    let router = std::sync::Arc::new(std::sync::RwLock::new(router));
+    let dispatcher = std::sync::Arc::new(std::sync::RwLock::new(dispatcher));
     let service = AppService::new(
         router,
         dispatcher,


### PR DESCRIPTION
## Summary
- fix route initialization in example code
- update template so generated projects wire the dispatcher correctly

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683a98a02df0832f8e2b27284c49560d