### PR TITLE
Enable static index and root

### DIFF
--- a/examples/pet_store/static_site/index.html
+++ b/examples/pet_store/static_site/index.html
@@ -1,0 +1,2 @@
+<h1>Pet Store</h1>
+<p>Welcome to the Pet Store example.</p>

--- a/src/generator/project/generate.rs
+++ b/src/generator/project/generate.rs
@@ -10,7 +10,7 @@ use crate::generator::schema::{
 };
 use crate::generator::templates::{
     write_cargo_toml, write_controller, write_handler, write_main_rs, write_mod_rs,
-    write_openapi_index, write_registry_rs, write_types_rs, RegistryEntry,
+    write_openapi_index, write_registry_rs, write_static_index, write_types_rs, RegistryEntry,
 };
 
 pub fn generate_project_from_spec(spec_path: &Path, force: bool) -> anyhow::Result<PathBuf> {
@@ -110,6 +110,7 @@ pub fn generate_project_from_spec(spec_path: &Path, force: bool) -> anyhow::Resu
     write_cargo_toml(&base_dir, &slug)?;
     write_main_rs(&src_dir, &slug, routes)?;
     write_openapi_index(&doc_dir)?;
+    write_static_index(&static_dir)?;
     write_types_rs(&handler_dir, &schema_types)?;
     write_registry_rs(&src_dir, &registry_entries)?;
     write_mod_rs(

--- a/src/generator/templates.rs
+++ b/src/generator/templates.rs
@@ -42,6 +42,10 @@ pub struct MainRsTemplateData {
 pub struct OpenapiIndexTemplate;
 
 #[derive(Template)]
+#[template(path = "static.index.html", escape = "none")]
+pub struct StaticIndexTemplate;
+
+#[derive(Template)]
 #[template(path = "mod.rs.txt")]
 pub struct ModRsTemplateData {
     pub modules: Vec<String>,
@@ -255,5 +259,12 @@ pub fn write_openapi_index(dir: &Path) -> anyhow::Result<()> {
     let rendered = OpenapiIndexTemplate.render()?;
     fs::write(dir.join("index.html"), rendered)?;
     println!("✅ Wrote docs index → {:?}", dir.join("index.html"));
+    Ok(())
+}
+
+pub fn write_static_index(dir: &Path) -> anyhow::Result<()> {
+    let rendered = StaticIndexTemplate.render()?;
+    fs::write(dir.join("index.html"), rendered)?;
+    println!("✅ Wrote static index → {:?}", dir.join("index.html"));
     Ok(())
 }

--- a/templates/static.index.html
+++ b/templates/static.index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>BRRTRouter Static Site</title>
+  </head>
+  <body>
+    <h1>It works!</h1>
+    <p>This is the default static index page.</p>
+  </body>
+</html>

--- a/tests/static_server_tests.rs
+++ b/tests/static_server_tests.rs
@@ -88,6 +88,16 @@ fn test_js_served() {
 }
 
 #[test]
+fn test_root_served() {
+    let (handle, addr) = start_service();
+    let resp = send_request(&addr, "GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+    handle.stop();
+    let (status, ct) = parse_parts(&resp);
+    assert_eq!(status, 200);
+    assert_eq!(ct, "text/html");
+}
+
+#[test]
 fn test_traversal_blocked() {
     let (handle, addr) = start_service();
     let resp = send_request(&addr, "GET /../Cargo.toml HTTP/1.1\r\nHost: x\r\n\r\n");

--- a/tests/staticdata/index.html
+++ b/tests/staticdata/index.html
@@ -1,0 +1,1 @@
+<h1>Hello Integration!</h1>


### PR DESCRIPTION
## Summary
- generate a default `index.html` for static files
- add template for static index
- update project generator to render the static index
- test that the server serves `/` correctly
- add simple index.html pages for pet_store example and tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683ab32500bc832f96ac92e503df2f83