### PR TITLE
Add runtime configuration and stack metrics

### DIFF
--- a/justfile
+++ b/justfile
@@ -30,8 +30,11 @@ fg:
 
 curls:
     curl -i 0.0.0.0:8080/health
+    echo ""
     curl -i 0.0.0.0:8080/metrics
+    echo ""
     curl -i "http://0.0.0.0:8080/items/123?debug=true" -X POST -H "Content-Type: application/json" -d '{"name": "Ball"}'
+    echo ""
     curl -i 0.0.0.0:8080
 
 all: gen build test curls

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod sse;
 pub mod static_files;
 pub mod typed;
 pub mod validator;
+pub mod runtime_config;
 
 pub use security::{BearerJwtProvider, OAuth2Provider, SecurityProvider, SecurityRequest};
 pub use spec::{

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -1,0 +1,24 @@
+use std::env;
+
+/// Runtime configuration loaded from environment variables.
+#[derive(Debug, Clone, Copy)]
+pub struct RuntimeConfig {
+    pub stack_size: usize,
+}
+
+impl RuntimeConfig {
+    /// Load configuration from environment variables.
+    pub fn from_env() -> Self {
+        let stack_size = match env::var("BRRTR_STACK_SIZE") {
+            Ok(val) => {
+                if let Some(hex) = val.strip_prefix("0x") {
+                    usize::from_str_radix(hex, 16).unwrap_or(0x4000)
+                } else {
+                    val.parse().unwrap_or(0x4000)
+                }
+            }
+            Err(_) => 0x4000,
+        };
+        RuntimeConfig { stack_size }
+    }
+}

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -69,15 +69,24 @@ pub fn health_endpoint(res: &mut Response) -> io::Result<()> {
 
 /// Metrics endpoint returning Prometheus text format statistics.
 pub fn metrics_endpoint(res: &mut Response, metrics: &MetricsMiddleware) -> io::Result<()> {
+    let (stack_size, used_stack) = metrics.stack_usage();
     let body = format!(
         "# HELP brrtrouter_requests_total Total number of handled requests\n\
          # TYPE brrtrouter_requests_total counter\n\
          brrtrouter_requests_total {}\n\
          # HELP brrtrouter_request_latency_seconds Average request latency in seconds\n\
          # TYPE brrtrouter_request_latency_seconds gauge\n\
-         brrtrouter_request_latency_seconds {}\n",
+         brrtrouter_request_latency_seconds {}\n\
+         # HELP brrtrouter_coroutine_stack_bytes Configured coroutine stack size\n\
+         # TYPE brrtrouter_coroutine_stack_bytes gauge\n\
+         brrtrouter_coroutine_stack_bytes {}\n\
+         # HELP brrtrouter_coroutine_stack_used_bytes Coroutine stack bytes used\n\
+         # TYPE brrtrouter_coroutine_stack_used_bytes gauge\n\
+         brrtrouter_coroutine_stack_used_bytes {}\n",
         metrics.request_count(),
-        metrics.average_latency().as_secs_f64()
+        metrics.average_latency().as_secs_f64(),
+        stack_size,
+        used_stack
     );
     write_handler_response(
         res,

--- a/templates/main.rs.txt
+++ b/templates/main.rs.txt
@@ -1,6 +1,7 @@
 {# templates/main.rs.txt #}
 use brrtrouter::dispatcher::Dispatcher;
 use brrtrouter::middleware::MetricsMiddleware;
+use brrtrouter::runtime_config::RuntimeConfig;
 use brrtrouter::server::AppService;
 use brrtrouter::server::HttpServer;
 use brrtrouter::{load_spec, router::Router};
@@ -20,23 +21,11 @@ struct Args {
     doc_dir: PathBuf,
 }
 
-fn parse_stack_size() -> usize {
-    if let Ok(val) = std::env::var("BRRTR_STACK_SIZE") {
-        if let Some(hex) = val.strip_prefix("0x") {
-            usize::from_str_radix(hex, 16).unwrap_or(0x4000)
-        } else {
-            val.parse().unwrap_or(0x4000)
-        }
-    } else {
-        0x4000
-    }
-}
-
 fn main() -> io::Result<()> {
     let args = Args::parse();
-    // increase coroutine stack size to prevent overflows
-    let stack_size = parse_stack_size();
-    may::config().set_stack_size(stack_size);
+    // configure coroutine stack size
+    let config = RuntimeConfig::from_env();
+    may::config().set_stack_size(config.stack_size);
     // Load OpenAPI spec and create router
     let (routes, _slug) = brrtrouter::spec::load_spec(args.spec.to_str().unwrap())
         .expect("failed to load OpenAPI spec");

--- a/tests/docs_endpoint_tests.rs
+++ b/tests/docs_endpoint_tests.rs
@@ -14,7 +14,8 @@ use tracing_util::TestTracing;
 
 fn start_service() -> (TestTracing, ServerHandle, SocketAddr) {
     std::env::set_var("BRRTR_STACK_SIZE", "0x8000");
-    may::config().set_stack_size(0x8000);
+    let config = brrtrouter::runtime_config::RuntimeConfig::from_env();
+    may::config().set_stack_size(config.stack_size);
     let tracing = TestTracing::init();
     let (routes, _slug) = brrtrouter::load_spec("examples/openapi.yaml").unwrap();
     let router = Arc::new(RwLock::new(Router::new(routes.clone())));

--- a/tests/health_endpoint_tests.rs
+++ b/tests/health_endpoint_tests.rs
@@ -15,7 +15,8 @@ use tracing_util::TestTracing;
 fn start_service() -> (TestTracing, ServerHandle, SocketAddr) {
     // ensure coroutines have enough stack for tests
     std::env::set_var("BRRTR_STACK_SIZE", "0x8000");
-    may::config().set_stack_size(0x8000);
+    let config = brrtrouter::runtime_config::RuntimeConfig::from_env();
+    may::config().set_stack_size(config.stack_size);
     let tracing = TestTracing::init();
     let (routes, _slug) = brrtrouter::load_spec("examples/openapi.yaml").unwrap();
     let router = Arc::new(RwLock::new(Router::new(routes.clone())));

--- a/tests/metrics_endpoint_tests.rs
+++ b/tests/metrics_endpoint_tests.rs
@@ -18,7 +18,8 @@ use tracing_util::TestTracing;
 
 fn start_service() -> (TestTracing, ServerHandle, SocketAddr) {
     std::env::set_var("BRRTR_STACK_SIZE", "0x8000");
-    may::config().set_stack_size(0x8000);
+    let config = brrtrouter::runtime_config::RuntimeConfig::from_env();
+    may::config().set_stack_size(config.stack_size);
     let tracing = TestTracing::init();
     let (routes, _slug) = brrtrouter::load_spec("examples/openapi.yaml").unwrap();
     let router = Arc::new(RwLock::new(Router::new(routes.clone())));
@@ -104,5 +105,7 @@ fn test_metrics_endpoint() {
     assert_eq!(ct, "text/plain");
     assert!(body.contains("brrtrouter_requests_total"));
     assert!(body.contains("brrtrouter_request_latency_seconds"));
+    assert!(body.contains("brrtrouter_coroutine_stack_bytes"));
+    assert!(body.contains("brrtrouter_coroutine_stack_used_bytes"));
     assert!(body.contains("brrtrouter_requests_total 1"));
 }

--- a/tests/sse_tests.rs
+++ b/tests/sse_tests.rs
@@ -16,7 +16,8 @@ use tracing_util::TestTracing;
 
 fn start_service() -> (TestTracing, ServerHandle, SocketAddr) {
     std::env::set_var("BRRTR_STACK_SIZE", "0x8000");
-    may::config().set_stack_size(0x8000);
+    let config = brrtrouter::runtime_config::RuntimeConfig::from_env();
+    may::config().set_stack_size(config.stack_size);
     let tracing = TestTracing::init();
     let (routes, _slug) = brrtrouter::load_spec("examples/openapi.yaml").unwrap();
     let router = Arc::new(RwLock::new(Router::new(routes.clone())));


### PR DESCRIPTION
## Summary
- add `RuntimeConfig` for configuring coroutine stack size
- use `RuntimeConfig` in example server and tests
- expose stack size metrics via MetricsMiddleware and `/metrics`

## Testing
- `cargo test --no-run`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683af4961fcc832f9e5aa0ff47ed8a6a