### PR TITLE
Implement hot reload dispatcher updates

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,6 +8,18 @@ default:
 gen:
     cargo run --bin brrtrouter-gen -- generate --spec examples/openapi.yaml --force
 
+# Run the CLI generate command for any spec
+generate spec="examples/openapi.yaml" force="":
+    cargo run --bin brrtrouter-gen -- generate --spec {{spec}} {{force}}
+
+# Serve a spec with echo handlers
+serve spec="examples/openapi.yaml" addr="0.0.0.0:8080":
+    cargo run --bin brrtrouter-gen -- serve --spec {{spec}} --addr {{addr}}
+
+# Serve a spec and watch for changes
+watch spec="examples/openapi.yaml" addr="0.0.0.0:8080":
+    cargo run --bin brrtrouter-gen -- serve --watch --spec {{spec}} --addr {{addr}}
+
 # Run tests with output
 build:
     cargo build

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -1,5 +1,9 @@
-use crate::load_spec;
+use crate::{load_spec, router::Router, dispatcher::Dispatcher, hot_reload::watch_spec, server::{AppService, HttpServer}};
 use clap::{Parser, Subcommand};
+use may::sync::mpsc;
+use may::coroutine;
+use std::sync::{Arc, RwLock};
+use std::io;
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -20,6 +24,17 @@ pub enum Commands {
         #[arg(short, long, default_value_t = false)]
         force: bool,
     },
+    /// Run the server for a spec using echo handlers
+    Serve {
+        #[arg(short, long)]
+        spec: PathBuf,
+
+        #[arg(long, default_value_t = false)]
+        watch: bool,
+
+        #[arg(long, default_value = "0.0.0.0:8080")]
+        addr: String,
+    },
 }
 
 pub fn run_cli() -> Result<(), Box<dyn std::error::Error>> {
@@ -33,6 +48,43 @@ pub fn run_cli() -> Result<(), Box<dyn std::error::Error>> {
             if let Err(e) = crate::generator::format_project(&project_dir) {
                 eprintln!("cargo fmt failed: {e}");
             }
+            Ok(())
+        }
+        Commands::Serve { spec, watch, addr } => {
+            let (routes, schemes, _slug) = crate::spec::load_spec_full(spec.to_str().unwrap())?;
+            let router = Arc::new(RwLock::new(Router::new(routes.clone())));
+            let mut dispatcher = Dispatcher::new();
+            for r in &routes {
+                let (tx, rx) = mpsc::channel();
+                unsafe {
+                    coroutine::spawn(move || {
+                        for req in rx.iter() {
+                            crate::echo::echo_handler(req);
+                        }
+                    });
+                }
+                dispatcher.add_route(r.clone(), tx);
+            }
+            let dispatcher = Arc::new(RwLock::new(dispatcher));
+            let mut service = AppService::new(router.clone(), dispatcher.clone(), schemes, spec.clone(), None, None);
+            if *watch {
+                let watcher = watch_spec(spec.clone(), router.clone(), dispatcher.clone(), |disp, new_routes| {
+                    for r in &new_routes {
+                        let (tx, rx) = mpsc::channel();
+                        unsafe {
+                            coroutine::spawn(move || {
+                                for req in rx.iter() {
+                                    crate::echo::echo_handler(req);
+                                }
+                            });
+                        }
+                        disp.add_route(r.clone(), tx);
+                    }
+                })?;
+                service.watcher = Some(watcher);
+            }
+            let handle = HttpServer(service).start(addr)?;
+            handle.join().map_err(|e| Box::<dyn std::error::Error>::from(io::Error::other(format!("{e:?}"))))?;
             Ok(())
         }
     }

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -13,7 +13,6 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
-#[derive(Clone)]
 pub struct AppService {
     pub router: Arc<RwLock<Router>>,
     pub dispatcher: Arc<RwLock<Dispatcher>>,
@@ -23,6 +22,23 @@ pub struct AppService {
     pub spec_path: PathBuf,
     pub static_files: Option<StaticFiles>,
     pub doc_files: Option<StaticFiles>,
+    pub watcher: Option<notify::RecommendedWatcher>,
+}
+
+impl Clone for AppService {
+    fn clone(&self) -> Self {
+        Self {
+            router: self.router.clone(),
+            dispatcher: self.dispatcher.clone(),
+            security_schemes: self.security_schemes.clone(),
+            security_providers: self.security_providers.clone(),
+            metrics: self.metrics.clone(),
+            spec_path: self.spec_path.clone(),
+            static_files: self.static_files.clone(),
+            doc_files: self.doc_files.clone(),
+            watcher: None,
+        }
+    }
 }
 
 impl AppService {
@@ -43,6 +59,7 @@ impl AppService {
             spec_path,
             static_files: static_dir.map(StaticFiles::new),
             doc_files: doc_dir.map(StaticFiles::new),
+            watcher: None,
         }
     }
 


### PR DESCRIPTION
## Summary
- update `watch_spec` to pass a dispatcher reference on reload
- store a `RecommendedWatcher` handle in `AppService`
- add `Serve` CLI command with `--watch` to run an echo server
- adjust hot reload tests for new callback signature
- add `generate`, `serve`, and `watch` tasks in `justfile`

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_683b0b593d1c832f89804c74dff2f32f