### PR TITLE
Add Docker support for pet_store example

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,19 @@ just coverage # runs `cargo llvm-cov --fail-under 80`
 
 The command fails if total coverage drops below 80%.
 
+## 🐳 Pet Store Docker Image
+
+The `examples/pet_store` application can be packaged as a Docker image for
+integration testing or deployment. A `Dockerfile` and `docker-compose.yml` are
+included. Build and run the container with:
+
+```bash
+docker compose up -d --build
+```
+
+The service listens on port `8080` and exposes the `/health` endpoint for
+readiness checks.
+
 
 Unit tests validate:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  petstore:
+    build: ./examples/pet_store
+    ports:
+      - "8080:8080"
+    environment:
+      - BRRTR_LOCAL=1

--- a/examples/pet_store/Dockerfile
+++ b/examples/pet_store/Dockerfile
@@ -1,0 +1,18 @@
+FROM rust:1.76 as builder
+WORKDIR /usr/src/app
+
+# cache deps
+COPY Cargo.toml Cargo.lock ./
+COPY examples/pet_store/Cargo.toml examples/pet_store/Cargo.toml
+COPY src ./src
+COPY examples/pet_store ./examples/pet_store
+COPY templates ./templates
+RUN cargo build -p pet_store --release
+
+FROM debian:buster-slim
+WORKDIR /app
+COPY --from=builder /usr/src/app/target/release/pet_store /app/pet_store
+COPY examples/pet_store/doc /app/doc
+EXPOSE 8080
+ENV BRRTR_LOCAL=1
+CMD ["/app/pet_store"]

--- a/tests/docker_integration_tests.rs
+++ b/tests/docker_integration_tests.rs
@@ -1,0 +1,36 @@
+use std::process::Command;
+use std::thread::sleep;
+use std::time::Duration;
+
+#[test]
+#[ignore]
+fn test_petstore_container_health() {
+    if Command::new("docker").arg("--version").output().is_err() {
+        eprintln!("Docker not installed; skipping");
+        return;
+    }
+    assert!(Command::new("docker")
+        .args(["compose", "up", "-d", "--build"])
+        .status()
+        .expect("docker compose up")
+        .success());
+
+    for _ in 0..30 {
+        let status = Command::new("curl")
+            .args(["-s", "-o", "/dev/null", "-w", "%{http_code}", "http://localhost:8080/health"])
+            .output()
+            .expect("curl");
+        if status.stdout == b"200" {
+            break;
+        }
+        sleep(Duration::from_secs(1));
+    }
+
+    let out = Command::new("curl")
+        .args(["-s", "-o", "/dev/null", "-w", "%{http_code}", "http://localhost:8080/health"])
+        .output()
+        .expect("curl request");
+    assert_eq!(out.stdout, b"200");
+
+    let _ = Command::new("docker").args(["compose", "down"]).status();
+}


### PR DESCRIPTION
## Summary
- add Dockerfile for pet_store example and expose port 8080
- add docker-compose.yml for launching the example container
- provide a README section describing the Docker image
- add ignored integration test that spins up the container via Docker Compose

## Testing
- `cargo test --locked -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_683a437dceb4832fb606994b3e4fb566