### PR TITLE
Update pet store Docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,21 @@ just coverage # runs `cargo llvm-cov --fail-under 80`
 
 The command fails if total coverage drops below 80%.
 
+## 🐳 Pet Store Docker Image
+
+The `examples/pet_store` application can be packaged as a Docker image for
+integration testing or deployment. A `Dockerfile` and `docker-compose.yml` are
+included. Build and run the container with:
+
+```bash
+docker compose up -d --build
+```
+
+The Dockerfile automatically runs the `brrtrouter-gen` generator so the example
+code is always up to date. The generated `doc` and `static_site` directories are
+copied into the final image. The service listens on port `8080` and exposes the
+`/health` endpoint for readiness checks.
+
 
 Unit tests validate:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  petstore:
+    build: ./examples/pet_store
+    ports:
+      - "8080:8080"
+    environment:
+      - BRRTR_LOCAL=1

--- a/examples/pet_store/Dockerfile
+++ b/examples/pet_store/Dockerfile
@@ -1,0 +1,23 @@
+FROM rust:1.76 as builder
+WORKDIR /usr/src/app
+
+# cache deps
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+COPY templates ./templates
+COPY examples/openapi.yaml examples/openapi.yaml
+
+# generate the example project from the latest OpenAPI spec
+RUN cargo run --bin brrtrouter-gen -- generate --spec examples/openapi.yaml --force
+
+# build the freshly generated pet_store example
+RUN cargo build -p pet_store --release
+
+FROM debian:buster-slim
+WORKDIR /app
+COPY --from=builder /usr/src/app/target/release/pet_store /app/pet_store
+COPY --from=builder /usr/src/app/examples/pet_store/doc /app/doc
+COPY --from=builder /usr/src/app/examples/pet_store/static_site /app/static_site
+EXPOSE 8080
+ENV BRRTR_LOCAL=1
+CMD ["/app/pet_store"]

--- a/tests/docker_integration_tests.rs
+++ b/tests/docker_integration_tests.rs
@@ -1,0 +1,36 @@
+use std::process::Command;
+use std::thread::sleep;
+use std::time::Duration;
+
+#[test]
+#[ignore]
+fn test_petstore_container_health() {
+    if Command::new("docker").arg("--version").output().is_err() {
+        eprintln!("Docker not installed; skipping");
+        return;
+    }
+    assert!(Command::new("docker")
+        .args(["compose", "up", "-d", "--build"])
+        .status()
+        .expect("docker compose up")
+        .success());
+
+    for _ in 0..30 {
+        let status = Command::new("curl")
+            .args(["-s", "-o", "/dev/null", "-w", "%{http_code}", "http://localhost:8080/health"])
+            .output()
+            .expect("curl");
+        if status.stdout == b"200" {
+            break;
+        }
+        sleep(Duration::from_secs(1));
+    }
+
+    let out = Command::new("curl")
+        .args(["-s", "-o", "/dev/null", "-w", "%{http_code}", "http://localhost:8080/health"])
+        .output()
+        .expect("curl request");
+    assert_eq!(out.stdout, b"200");
+
+    let _ = Command::new("docker").args(["compose", "down"]).status();
+}


### PR DESCRIPTION
## Summary
- regenerate pet store during Docker build
- copy generated docs and static assets into the container
- note Docker build behaviour in README

## Testing
- `cargo test --locked -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_683a437dceb4832fb606994b3e4fb566