### PR TITLE
Add preflight handling to CORS middleware

### DIFF
--- a/src/middleware/cors.rs
+++ b/src/middleware/cors.rs
@@ -1,21 +1,77 @@
+use std::collections::HashMap;
 use std::time::Duration;
+
+use http::Method;
+use serde_json::Value;
 
 use super::Middleware;
 use crate::dispatcher::{HandlerRequest, HandlerResponse};
 
-pub struct CorsMiddleware;
+pub struct CorsMiddleware {
+    allowed_origins: Vec<String>,
+    allowed_headers: Vec<String>,
+    allowed_methods: Vec<Method>,
+}
+
+impl CorsMiddleware {
+    pub fn new(
+        allowed_origins: Vec<String>,
+        allowed_headers: Vec<String>,
+        allowed_methods: Vec<Method>,
+    ) -> Self {
+        Self {
+            allowed_origins,
+            allowed_headers,
+            allowed_methods,
+        }
+    }
+}
+
+impl Default for CorsMiddleware {
+    fn default() -> Self {
+        Self {
+            allowed_origins: vec!["*".into()],
+            allowed_headers: vec!["Content-Type".into(), "Authorization".into()],
+            allowed_methods: vec![
+                Method::GET,
+                Method::POST,
+                Method::PUT,
+                Method::DELETE,
+                Method::OPTIONS,
+            ],
+        }
+    }
+}
 
 impl Middleware for CorsMiddleware {
+    fn before(&self, req: &HandlerRequest) -> Option<HandlerResponse> {
+        if req.method == Method::OPTIONS {
+            Some(HandlerResponse {
+                status: 204,
+                headers: HashMap::new(),
+                body: Value::Null,
+            })
+        } else {
+            None
+        }
+    }
+
     fn after(&self, _req: &HandlerRequest, res: &mut HandlerResponse, _latency: Duration) {
+        let origins = self.allowed_origins.join(", ");
         res.headers
-            .insert("Access-Control-Allow-Origin".into(), "*".into());
-        res.headers.insert(
-            "Access-Control-Allow-Headers".into(),
-            "Content-Type, Authorization".into(),
-        );
-        res.headers.insert(
-            "Access-Control-Allow-Methods".into(),
-            "GET, POST, PUT, DELETE, OPTIONS".into(),
-        );
+            .insert("Access-Control-Allow-Origin".into(), origins);
+
+        let headers = self.allowed_headers.join(", ");
+        res.headers
+            .insert("Access-Control-Allow-Headers".into(), headers);
+
+        let methods = self
+            .allowed_methods
+            .iter()
+            .map(|m| m.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        res.headers
+            .insert("Access-Control-Allow-Methods".into(), methods);
     }
 }

--- a/tests/auth_cors_tests.rs
+++ b/tests/auth_cors_tests.rs
@@ -48,7 +48,7 @@ fn test_auth_middleware_blocks_invalid_token() {
 
 #[test]
 fn test_cors_middleware_sets_headers() {
-    let mw = CorsMiddleware;
+    let mw = CorsMiddleware::default();
     let (tx, _rx) = mpsc::channel::<HandlerResponse>();
     let req = HandlerRequest {
         method: Method::GET,

--- a/tests/middleware_tests.rs
+++ b/tests/middleware_tests.rs
@@ -1,10 +1,16 @@
 use brrtrouter::{
-    dispatcher::Dispatcher, load_spec, middleware::MetricsMiddleware, router::Router,
+    dispatcher::{Dispatcher, HandlerRequest, HandlerResponse},
+    load_spec,
+    middleware::{CorsMiddleware, MetricsMiddleware},
+    middleware::Middleware,
+    router::Router,
 };
 use http::Method;
 use pet_store::registry;
 use std::collections::HashMap;
 use std::sync::Arc;
+use may::sync::mpsc;
+use std::time::Duration;
 
 mod tracing_util;
 use brrtrouter::middleware::TracingMiddleware;
@@ -57,4 +63,77 @@ fn test_metrics_stack_usage() {
     assert_eq!(size, 0x801);
     assert!(used >= 0);
     // tracing.wait_for_span("get_pet");
+}
+
+#[test]
+fn test_cors_custom_headers() {
+    let mw = CorsMiddleware::new(
+        vec!["https://example.com".into()],
+        vec!["X-Token".into()],
+        vec![Method::GET, Method::POST],
+    );
+
+    let (tx, _rx) = mpsc::channel::<HandlerResponse>();
+    let req = HandlerRequest {
+        method: Method::GET,
+        path: "/".into(),
+        handler_name: "test".into(),
+        path_params: HashMap::new(),
+        query_params: HashMap::new(),
+        headers: HashMap::new(),
+        cookies: HashMap::new(),
+        body: None,
+        reply_tx: tx,
+    };
+    let mut resp = HandlerResponse {
+        status: 200,
+        headers: HashMap::new(),
+        body: serde_json::Value::Null,
+    };
+    mw.after(&req, &mut resp, Duration::from_millis(0));
+    assert_eq!(
+        resp.headers.get("Access-Control-Allow-Origin"),
+        Some(&"https://example.com".to_string())
+    );
+    assert_eq!(
+        resp.headers.get("Access-Control-Allow-Headers"),
+        Some(&"X-Token".to_string())
+    );
+    assert_eq!(
+        resp.headers.get("Access-Control-Allow-Methods"),
+        Some(&"GET, POST".to_string())
+    );
+}
+
+#[test]
+fn test_cors_preflight_response() {
+    let mw = CorsMiddleware::default();
+
+    let (tx, _rx) = mpsc::channel::<HandlerResponse>();
+    let req = HandlerRequest {
+        method: Method::OPTIONS,
+        path: "/".into(),
+        handler_name: "test".into(),
+        path_params: HashMap::new(),
+        query_params: HashMap::new(),
+        headers: HashMap::new(),
+        cookies: HashMap::new(),
+        body: None,
+        reply_tx: tx,
+    };
+    let mut resp = mw.before(&req).expect("should return response");
+    assert_eq!(resp.status, 204);
+    mw.after(&req, &mut resp, Duration::from_millis(0));
+    assert_eq!(
+        resp.headers.get("Access-Control-Allow-Origin"),
+        Some(&"*".to_string())
+    );
+    assert_eq!(
+        resp.headers.get("Access-Control-Allow-Headers"),
+        Some(&"Content-Type, Authorization".to_string())
+    );
+    assert_eq!(
+        resp.headers.get("Access-Control-Allow-Methods"),
+        Some(&"GET, POST, PUT, DELETE, OPTIONS".to_string())
+    );
 }


### PR DESCRIPTION
## Summary
- refactor `CorsMiddleware` to store allowed origins, headers and methods
- support OPTIONS preflight handling
- test custom CORS headers and preflight behaviour

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683b5a02b8e0832f9ee51686cff66b17