### PR TITLE
Add body validation via jsonschema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.3.3",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -314,6 +315,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +388,7 @@ dependencies = [
  "fake-opentelemetry-collector",
  "flamegraph",
  "http 1.3.1",
+ "jsonschema",
  "may",
  "may_minihttp",
  "minijinja",
@@ -408,6 +425,12 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "bytecount"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
@@ -875,6 +898,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +961,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1049,8 +1092,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1541,6 +1586,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "iso8601"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1572,6 +1626,36 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "base64 0.21.7",
+ "bytecount",
+ "clap",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.2.16",
+ "iso8601",
+ "itoa",
+ "memchr",
+ "num-cmp",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -1800,6 +1884,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "normpath"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,6 +1931,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1851,6 +1983,37 @@ checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
  "arrayvec",
  "itoa",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -2831,6 +2994,7 @@ dependencies = [
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -2838,6 +3002,16 @@ name = "time-core"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = [".github/"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+jsonschema = "0.17"
 serde_yaml = "0.9"
 # Needed for simple JWT parsing in security providers
 base64 = "0.22"

--- a/examples/pet_store/doc/index.html
+++ b/examples/pet_store/doc/index.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html>
   <head>

--- a/examples/pet_store/static_site/index.html
+++ b/examples/pet_store/static_site/index.html
@@ -1,2 +1,11 @@
-<h1>Pet Store</h1>
-<p>Welcome to the Pet Store example.</p>
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>BRRTRouter Static Site</title>
+  </head>
+  <body>
+    <h1>It works!</h1>
+    <p>This is the default static index page.</p>
+  </body>
+</html>

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -8,6 +8,7 @@ use crate::spec::SecurityScheme;
 use crate::static_files::StaticFiles;
 use may_minihttp::{HttpService, Request, Response};
 use serde_json::json;
+use jsonschema::JSONSchema;
 use std::collections::HashMap;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -207,6 +208,18 @@ impl HttpService for AppService {
         };
         if let Some(mut route_match) = route_opt {
             route_match.query_params = query_params.clone();
+            if let (Some(schema), Some(body_val)) = (&route_match.route.request_schema, &body) {
+                let compiled = JSONSchema::compile(schema).expect("invalid request schema");
+                if let Err(errors) = compiled.validate(body_val) {
+                    let details: Vec<String> = errors.map(|e| e.to_string()).collect();
+                    write_json_error(
+                        res,
+                        400,
+                        json!({"error": "Request validation failed", "details": details}),
+                    );
+                    return Ok(());
+                }
+            }
             if !route_match.route.security.is_empty() {
                 let sec_req = SecurityRequest {
                     headers: &headers,
@@ -257,6 +270,18 @@ impl HttpService for AppService {
                     if !headers.contains_key("Content-Type") {
                         if let Some(ct) = route_match.route.content_type_for(hr.status) {
                             headers.insert("Content-Type".to_string(), ct);
+                        }
+                    }
+                    if let Some(schema) = &route_match.route.response_schema {
+                        let compiled = JSONSchema::compile(schema).expect("invalid response schema");
+                        if let Err(errors) = compiled.validate(&hr.body) {
+                            let details: Vec<String> = errors.map(|e| e.to_string()).collect();
+                            write_json_error(
+                                res,
+                                400,
+                                json!({"error": "Response validation failed", "details": details}),
+                            );
+                            return Ok(());
                         }
                     }
                     write_handler_response(res, hr.status, hr.body, is_sse, &headers);

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -218,7 +218,7 @@ impl HttpService for AppService {
                         json!({"error": "Request validation failed", "details": details}),
                     );
                     return Ok(());
-                }
+                };
             }
             if !route_match.route.security.is_empty() {
                 let sec_req = SecurityRequest {
@@ -282,7 +282,7 @@ impl HttpService for AppService {
                                 json!({"error": "Response validation failed", "details": details}),
                             );
                             return Ok(());
-                        }
+                        };
                     }
                     write_handler_response(res, hr.status, hr.body, is_sse, &headers);
                 }

--- a/tests/server_tests.rs
+++ b/tests/server_tests.rs
@@ -354,3 +354,127 @@ fn test_text_plain_error() {
     assert_eq!(raw_body, "bad request");
     assert_eq!(body, Value::String("bad request".to_string()));
 }
+
+#[test]
+fn test_request_body_validation_failure() {
+    may::config().set_stack_size(0x8000);
+    let _tracing = TestTracing::init();
+    fn echo_handler(req: HandlerRequest) {
+        let response = HandlerResponse {
+            status: 200,
+            headers: HashMap::new(),
+            body: json!({"ok": true}),
+        };
+        let _ = req.reply_tx.send(response);
+    }
+
+    let route = RouteMeta {
+        method: Method::POST,
+        path_pattern: "/echo".to_string(),
+        handler_name: "echo".to_string(),
+        parameters: Vec::new(),
+        request_schema: Some(json!({
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"]
+        })),
+        response_schema: None,
+        example: None,
+        responses: std::collections::HashMap::new(),
+        security: Vec::new(),
+        example_name: String::new(),
+        project_slug: String::new(),
+        output_dir: PathBuf::new(),
+        base_path: String::new(),
+        sse: false,
+    };
+    let router = Arc::new(RwLock::new(Router::new(vec![route])));
+    let mut dispatcher = Dispatcher::new();
+    unsafe {
+        dispatcher.register_handler("echo", echo_handler);
+    }
+    dispatcher.add_middleware(Arc::new(TracingMiddleware));
+    let service = AppService::new(
+        router,
+        Arc::new(RwLock::new(dispatcher)),
+        HashMap::new(),
+        PathBuf::from("examples/openapi.yaml"),
+        None,
+        None,
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    let handle = HttpServer(service).start(addr).unwrap();
+
+    let request = concat!(
+        "POST /echo HTTP/1.1\r\n",
+        "Host: localhost\r\n",
+        "Content-Type: application/json\r\n",
+        "Content-Length: 13\r\n",
+        "\r\n",
+        "{\"name\":123}"
+    );
+    let resp = send_request(&addr, request);
+    handle.stop();
+    let (status, _body) = parse_response(&resp);
+    assert_eq!(status, 400);
+}
+
+#[test]
+fn test_response_body_validation_failure() {
+    may::config().set_stack_size(0x8000);
+    let _tracing = TestTracing::init();
+    fn bad_handler(req: HandlerRequest) {
+        let response = HandlerResponse {
+            status: 200,
+            headers: HashMap::new(),
+            body: json!({"name": 123}),
+        };
+        let _ = req.reply_tx.send(response);
+    }
+
+    let route = RouteMeta {
+        method: Method::GET,
+        path_pattern: "/bad".to_string(),
+        handler_name: "bad".to_string(),
+        parameters: Vec::new(),
+        request_schema: None,
+        response_schema: Some(json!({
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"]
+        })),
+        example: None,
+        responses: std::collections::HashMap::new(),
+        security: Vec::new(),
+        example_name: String::new(),
+        project_slug: String::new(),
+        output_dir: PathBuf::new(),
+        base_path: String::new(),
+        sse: false,
+    };
+    let router = Arc::new(RwLock::new(Router::new(vec![route])));
+    let mut dispatcher = Dispatcher::new();
+    unsafe {
+        dispatcher.register_handler("bad", bad_handler);
+    }
+    dispatcher.add_middleware(Arc::new(TracingMiddleware));
+    let service = AppService::new(
+        router,
+        Arc::new(RwLock::new(dispatcher)),
+        HashMap::new(),
+        PathBuf::from("examples/openapi.yaml"),
+        None,
+        None,
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    let handle = HttpServer(service).start(addr).unwrap();
+
+    let resp = send_request(&addr, "GET /bad HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    handle.stop();
+    let (status, _body) = parse_response(&resp);
+    assert_eq!(status, 400);
+}


### PR DESCRIPTION
## Summary
- add `jsonschema` dependency
- validate request/response bodies in server
- test validation errors return 400

## Testing
- `cargo test --quiet` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683b6498c050832f9a6078c3e1fbe82c