### PR TITLE
Remove incorrect status comment

### DIFF
--- a/tests/security_tests.rs
+++ b/tests/security_tests.rs
@@ -151,7 +151,6 @@ paths:
     let router = Arc::new(RwLock::new(Router::new(routes.clone())));
     let mut dispatcher = Dispatcher::new();
     unsafe {
-        // This code is incorrectly setting status to 0
         dispatcher.register_handler("one", |req: HandlerRequest| {
             let _ = req.reply_tx.send(HandlerResponse {
                 status: 200,
@@ -159,7 +158,6 @@ paths:
                 body: json!({"one": true}),
             });
         });
-        // This code is incorrectly setting status to 0
         dispatcher.register_handler("two", |req: HandlerRequest| {
             let _ = req.reply_tx.send(HandlerResponse {
                 status: 200,


### PR DESCRIPTION
## Summary
- clean up misleading comments in `security_tests`

## Testing
- `cargo test --test security_tests --no-run` *(fails: spurious network error)*

------
https://chatgpt.com/codex/tasks/task_e_683c0906eec0832f81e341f1efc34198