### PR TITLE
Add handler macro crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.3.3",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -314,6 +315,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +388,7 @@ dependencies = [
  "fake-opentelemetry-collector",
  "flamegraph",
  "http 1.3.1",
+ "jsonschema",
  "may",
  "may_minihttp",
  "minijinja",
@@ -393,6 +410,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "brrtrouter_macros"
+version = "0.1.0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +435,12 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "bytecount"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
@@ -875,6 +908,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +971,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1049,8 +1102,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1535,6 +1590,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "iso8601"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,6 +1630,36 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "base64 0.21.7",
+ "bytecount",
+ "clap",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.2.16",
+ "iso8601",
+ "itoa",
+ "memchr",
+ "num-cmp",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -1794,6 +1888,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "normpath"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,6 +1935,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,6 +1987,37 @@ checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
  "arrayvec",
  "itoa",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -2082,6 +2255,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "brrtrouter",
+ "brrtrouter_macros",
  "clap",
  "http 1.3.1",
  "may",
@@ -2825,6 +2999,7 @@ dependencies = [
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -2832,6 +3007,16 @@ name = "time-core"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,5 +57,6 @@ harness = false
 
 [workspace]
 members = [
+    "brrtrouter_macros",
     "examples/pet_store"
 ]

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The logo features a stylized **A-10 Warthog nose cannon**, symbolizing BRRTRoute
 | **Hot reload on spec change**                    | 🚧     | `hot_reload::watch_spec` rebuilds the `Router`, but the server doesn’t automatically update the dispatcher or routes.                                                     |
 | **Code generation for typed handlers**           | 🚧     | Implemented via templates generating `TryFrom<HandlerRequest>` impls.                                                                                                     |
 | **Dynamic route registration**                   | 🚧     | `Dispatcher::add_route` and `register_from_spec` allow runtime insertion; tests cover this.                                                                               |
-| **Improved handler ergonomics**                  | 🚧     | Handlers still operate on explicit `TypedHandlerRequest` objects; no macro or higher-level abstraction.                                                                   |
+| **Improved handler ergonomics**                  | ✅     | Use `#[handler]` to implement the `Handler` trait automatically. |
 | **Structured tracing / metrics / CORS**          | 🚧     | Tracing and metrics middleware exist (with OTEL test support); CORS middleware returns default headers but is not configurable.                                           |
 | **Schema validation**                            | 🚧     | Request/response validation against OpenAPI schema is not implemented.                                                                                                    |
 | **WebSocket support**                            | 🚧     | Absent. Only SSE is available via `x-sse` flag.                                                                                                                           |
@@ -214,6 +214,20 @@ dispatcher.register_handler("post_item", echo_handler);
 ```
 
 Each handler runs in its own coroutine, receiving requests via a channel and sending back structured HandlerResponse.
+
+### Using `#[handler]`
+
+Controllers can derive the `Handler` trait automatically with the procedural macro:
+
+```rust
+use brrtrouter_macros::handler;
+use brrtrouter::typed::TypedHandlerRequest;
+
+#[handler(MyController)]
+pub fn handle(req: TypedHandlerRequest<MyRequest>) -> MyResponse {
+    // ...
+}
+```
 
 ---
 ## 🔌 Middleware

--- a/brrtrouter_macros/Cargo.toml
+++ b/brrtrouter_macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "brrtrouter_macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }
+heck = "0.5"

--- a/brrtrouter_macros/src/lib.rs
+++ b/brrtrouter_macros/src/lib.rs
@@ -1,0 +1,86 @@
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{parse_macro_input, parse::Parse, parse::ParseStream, FnArg, Ident, ItemFn, ReturnType, Type};
+use heck::ToUpperCamelCase;
+
+struct Attr(Option<Ident>);
+
+impl Parse for Attr {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.is_empty() {
+            return Ok(Attr(None));
+        }
+        let ident: Ident = input.parse()?;
+        Ok(Attr(Some(ident)))
+    }
+}
+
+#[proc_macro_attribute]
+pub fn handler(attr: TokenStream, item: TokenStream) -> TokenStream {
+    // Parse function
+    let input_fn = parse_macro_input!(item as ItemFn);
+    let attr_args = parse_macro_input!(attr as Attr);
+
+    // Determine struct name
+    let struct_ident: Ident = if let Some(first) = attr_args.0 {
+        first
+    } else {
+        let fn_name = input_fn.sig.ident.to_string();
+        let camel = fn_name.to_upper_camel_case();
+        format_ident!("{}Controller", camel)
+    };
+
+    // Extract request type from first argument
+    let first_arg = input_fn
+        .sig
+        .inputs
+        .first()
+        .expect("handler must have one argument");
+    let typed_req_ty = match first_arg {
+        FnArg::Typed(pt) => (*pt.ty).clone(),
+        _ => panic!("expected typed argument"),
+    };
+
+    let req_ty = if let Type::Path(tp) = &typed_req_ty {
+        let seg = tp.path.segments.last().expect("bad type");
+        if seg.ident != "TypedHandlerRequest" {
+            panic!("first argument must be TypedHandlerRequest<T>");
+        }
+        if let syn::PathArguments::AngleBracketed(ab) = &seg.arguments {
+            if let Some(syn::GenericArgument::Type(inner)) = ab.args.first() {
+                inner.clone()
+            } else {
+                panic!("missing generic argument");
+            }
+        } else {
+            panic!("expected generic argument");
+        }
+    } else {
+        panic!("expected TypedHandlerRequest type");
+    };
+
+    // Extract response type
+    let resp_ty: Type = match &input_fn.sig.output {
+        ReturnType::Type(_, ty) => (**ty).clone(),
+        ReturnType::Default => syn::parse_quote!(()),
+    };
+
+    let fn_name = &input_fn.sig.ident;
+    let vis = &input_fn.vis;
+
+    let output = quote! {
+        #input_fn
+
+        #vis struct #struct_ident;
+
+        impl brrtrouter::typed::Handler for #struct_ident {
+            type Request = #req_ty;
+            type Response = #resp_ty;
+            fn handle(&self, req: brrtrouter::typed::TypedHandlerRequest<#req_ty>) -> #resp_ty {
+                #fn_name(req)
+            }
+        }
+    };
+
+    output.into()
+}

--- a/examples/pet_store/Cargo.toml
+++ b/examples/pet_store/Cargo.toml
@@ -13,3 +13,4 @@ may = "0.3"
 may_minihttp = "0.1"
 anyhow = "1.0"
 clap = { version = "4.5.39", features = ["derive"] }
+brrtrouter_macros = { path = "../../brrtrouter_macros" }

--- a/examples/pet_store/src/controllers/get_user.rs
+++ b/examples/pet_store/src/controllers/get_user.rs
@@ -1,25 +1,17 @@
 // User-owned controller for handler 'get_user'.
-use crate::brrtrouter::typed::{Handler, TypedHandlerRequest};
+use brrtrouter_macros::handler;
+use crate::brrtrouter::typed::TypedHandlerRequest;
 use crate::handlers::get_user::{Request, Response};
 
-pub struct GetUserController;
-
-impl Handler for GetUserController {
-    type Request = Request;
-    type Response = Response;
-    fn handle(&self, _req: TypedHandlerRequest<Request>) -> Response {
-        // Example response:
-        // {
-        //   "id": "abc-123",
-        //   "name": "John"
-        // }
-        Response {
-            id: Some("abc-123".to_string()),
-            name: Some("John".to_string()),
-        }
+#[handler(GetUserController)]
+pub fn handle(_req: TypedHandlerRequest<Request>) -> Response {
+    // Example response:
+    // {
+    //   "id": "abc-123",
+    //   "name": "John"
+    // }
+    Response {
+        id: Some("abc-123".to_string()),
+        name: Some("John".to_string()),
     }
-}
-
-pub fn handle(req: TypedHandlerRequest<Request>) -> Response {
-    GetUserController.handle(req)
 }


### PR DESCRIPTION
## Summary
- implement `brrtrouter_macros` proc-macro crate and workspace entry
- support `#[handler]` attribute for typed controllers
- refactor `get_user` controller to use the macro
- document the new macro in README

## Testing
- `cargo build --workspace --offline --quiet`
- `cargo test --workspace --offline --quiet` *(fails: test_dispatch_success)*

------
https://chatgpt.com/codex/tasks/task_e_683cbf75d5d0832fa6c9741919e287eb