### PR TITLE
Add contribution docs and revert generated file edit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Guidance for Automated Contributors
+
+- **Do not edit files under `examples/` manually.** These are generated from templates in `templates/` using the code in `src/generator/`.
+- Update the templates or generator, then run the generator command as described in `CONTRIBUTING.md`.
+- Run `cargo fmt` and `cargo test` before committing changes.
+- See `CONTRIBUTING.md` for a full description of the repository layout and workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing to BRRTRouter
+
+Thank you for your interest in contributing! This project includes a code generator and example output. Please do **not** edit files under `examples/` manually; they are generated from templates.
+
+## Development Workflow
+
+1. Modify templates under `templates/` or the generator logic in `src/generator/`.
+2. Regenerate the example project with:
+   ```bash
+   cargo run --bin brrtrouter-gen -- generate --spec examples/openapi.yaml --force
+   ```
+   or simply run `just gen` if you have `just` installed.
+3. Run `cargo fmt` and `cargo test` before submitting a pull request.
+
+## Code Base Overview
+
+The `src/` directory is organized into several modules:
+
+- **`cli`** – command-line interface and entry points for the generator.
+- **`dispatcher`** – coroutine-based dispatcher that invokes handlers for matched routes.
+- **`router`** – path matcher that builds a routing table from the OpenAPI spec.
+- **`server`** – lightweight HTTP server built on `may_minihttp` plus request/response types.
+- **`middleware`** – pluggable middleware such as metrics, CORS, and security hooks.
+- **`security`** – implementations of bearer and OAuth2 security providers.
+- **`generator`** – reads templates and the OpenAPI spec to produce example projects.
+- **`spec`** – OpenAPI 3.1 parser used by the router and generator.
+- **`typed`** – traits for typed request/response handlers.
+- **`runtime_config`** – loads runtime options from environment variables.
+- **`sse`** and **`static_files`** – helpers for server-sent events and serving static assets.
+
+Key components include:
+
+- `Router` – performs regex-based path matching and extracts path parameters.
+- `Dispatcher` – coordinates coroutine execution of request handlers.
+- `HttpServer` – drives the request/response loop and integrates middleware.
+
+For more details, consult the inline documentation in each module. Contributions that improve tests and documentation are highly appreciated!

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ See [`examples/openapi.yaml`](examples/openapi.yaml) for the sample `/events` en
 ---
 ## 📈 Contributing & Benchmarks
 For a detailed view of completed and upcoming work, see [docs/ROADMAP.md](docs/ROADMAP.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow and repository layout.
 We welcome contributions that improve:
 - 🧵 Typed handler deserialization
 - ✨ Auto-generation of impl `From<HandlerRequest>` for `TypedHandlerRequest<T>` based on schema


### PR DESCRIPTION
## Summary
- revert direct edit to example Cargo.toml
- add CONTRIBUTING guide with code base overview and workflow details
- document agent guidelines in AGENTS.md
- link README's contribution section to the new guide

## Testing
- `cargo fmt` *(failed: rustfmt not installed)*
- `cargo test` *(failed: test_dispatch_success)*

------
https://chatgpt.com/codex/tasks/task_e_683ccc4933d8832fb6aa1345ac52b2b7