### PR TITLE
Add schema ref expansion

### DIFF
--- a/examples/pet_store/src/controllers/add_pet.rs
+++ b/examples/pet_store/src/controllers/add_pet.rs
@@ -14,10 +14,12 @@ pub fn handle(_req: TypedHandlerRequest<Request>) -> Response {
         //   "id": 67890,
         //   "status": "success"
         // }
+    
     Response {
         id: Some(67890),
         status: Some("success".to_string()),
         
     }
+    
     
 }

--- a/examples/pet_store/src/controllers/admin_settings.rs
+++ b/examples/pet_store/src/controllers/admin_settings.rs
@@ -16,9 +16,11 @@ pub fn handle(_req: TypedHandlerRequest<Request>) -> Response {
         //     "beta": true
         //   }
         // }
+    
     Response {
         feature_flags: Some(serde_json::json!({"analytics":false,"beta":true})),
         
     }
+    
     
 }

--- a/examples/pet_store/src/controllers/get_item.rs
+++ b/examples/pet_store/src/controllers/get_item.rs
@@ -14,10 +14,12 @@ pub fn handle(_req: TypedHandlerRequest<Request>) -> Response {
         //   "id": "item-001",
         //   "name": "Sample Item"
         // }
+    
     Response {
         id: Some("item-001".to_string()),
         name: Some("Sample Item".to_string()),
         
     }
+    
     
 }

--- a/examples/pet_store/src/controllers/get_pet.rs
+++ b/examples/pet_store/src/controllers/get_pet.rs
@@ -21,6 +21,7 @@ pub fn handle(_req: TypedHandlerRequest<Request>) -> Response {
         //   ],
         //   "vaccinated": true
         // }
+    
     Response {
         age: 3,
         breed: "Golden Retriever".to_string(),
@@ -30,5 +31,6 @@ pub fn handle(_req: TypedHandlerRequest<Request>) -> Response {
         vaccinated: true,
         
     }
+    
     
 }

--- a/examples/pet_store/src/controllers/get_post.rs
+++ b/examples/pet_store/src/controllers/get_post.rs
@@ -15,11 +15,13 @@ pub fn handle(_req: TypedHandlerRequest<Request>) -> Response {
         //   "id": "post1",
         //   "title": "Intro"
         // }
+    
     Response {
         body: Some("Welcome to the blog".to_string()),
         id: Some("post1".to_string()),
         title: Some("Intro".to_string()),
         
     }
+    
     
 }

--- a/examples/pet_store/src/controllers/get_user.rs
+++ b/examples/pet_store/src/controllers/get_user.rs
@@ -14,10 +14,12 @@ pub fn handle(_req: TypedHandlerRequest<Request>) -> Response {
         //   "id": "abc-123",
         //   "name": "John"
         // }
+    
     Response {
         id: Some("abc-123".to_string()),
         name: Some("John".to_string()),
         
     }
+    
     
 }

--- a/examples/pet_store/src/controllers/list_pets.rs
+++ b/examples/pet_store/src/controllers/list_pets.rs
@@ -35,9 +35,8 @@ pub fn handle(_req: TypedHandlerRequest<Request>) -> Response {
         //     "vaccinated": true
         //   }
         // ]
-    Response {
-        items: vec![Default::default()],
-        
-    }
+    
+    Response(vec![Default::default()])
+    
     
 }

--- a/examples/pet_store/src/controllers/list_user_posts.rs
+++ b/examples/pet_store/src/controllers/list_user_posts.rs
@@ -23,9 +23,8 @@ pub fn handle(_req: TypedHandlerRequest<Request>) -> Response {
         //     "title": "Follow-up"
         //   }
         // ]
-    Response {
-        items: vec![Default::default()],
-        
-    }
+    
+    Response(vec![Default::default()])
+    
     
 }

--- a/examples/pet_store/src/controllers/list_users.rs
+++ b/examples/pet_store/src/controllers/list_users.rs
@@ -23,9 +23,11 @@ pub fn handle(_req: TypedHandlerRequest<Request>) -> Response {
         //     }
         //   ]
         // }
+    
     Response {
         users: Some(vec![serde_json::from_value::<User>(serde_json::json!({"id":"abc-123","name":"John"})).unwrap(), serde_json::from_value::<User>(serde_json::json!({"id":"def-456","name":"Jane"})).unwrap()]),
         
     }
+    
     
 }

--- a/examples/pet_store/src/controllers/post_item.rs
+++ b/examples/pet_store/src/controllers/post_item.rs
@@ -14,10 +14,12 @@ pub fn handle(_req: TypedHandlerRequest<Request>) -> Response {
         //   "id": "item-001",
         //   "name": "New Item"
         // }
+    
     Response {
         id: Some("item-001".to_string()),
         name: Some("New Item".to_string()),
         
     }
+    
     
 }

--- a/examples/pet_store/src/handlers/list_pets.rs
+++ b/examples/pet_store/src/handlers/list_pets.rs
@@ -16,10 +16,7 @@ pub struct Request {
 
 #[derive(Debug, Serialize)]
 
-pub struct Response {
-    pub items: Vec<Pet>,
-    
-    }
+pub struct Response(pub Vec<Pet>);
 
 
 impl TryFrom<HandlerRequest> for Request {

--- a/examples/pet_store/src/handlers/list_user_posts.rs
+++ b/examples/pet_store/src/handlers/list_user_posts.rs
@@ -18,10 +18,7 @@ pub struct Request {
 
 #[derive(Debug, Serialize)]
 
-pub struct Response {
-    pub items: Vec<Post>,
-    
-    }
+pub struct Response(pub Vec<Post>);
 
 
 impl TryFrom<HandlerRequest> for Request {

--- a/src/generator/schema.rs
+++ b/src/generator/schema.rs
@@ -184,7 +184,9 @@ pub fn extract_fields(schema: &Value) -> Vec<FieldDef> {
         .unwrap_or_default();
     if let Some(props) = schema.get("properties").and_then(|p| p.as_object()) {
         for (name, prop) in props {
-            let ty = if let Some(r) = prop.get("$ref").and_then(|v| v.as_str()) {
+            let ty = if let Some(name) = prop.get("x-ref-name").and_then(|v| v.as_str()) {
+                to_camel_case(name)
+            } else if let Some(r) = prop.get("$ref").and_then(|v| v.as_str()) {
                 if let Some(name) = r.strip_prefix("#/components/schemas/") {
                     to_camel_case(name)
                 } else {
@@ -222,6 +224,9 @@ pub fn extract_fields(schema: &Value) -> Vec<FieldDef> {
 }
 
 pub fn schema_to_type(schema: &Value) -> String {
+    if let Some(name) = schema.get("x-ref-name").and_then(|v| v.as_str()) {
+        return to_camel_case(name);
+    }
     if let Some(r) = schema.get("$ref").and_then(|v| v.as_str()) {
         if let Some(name) = r.strip_prefix("#/components/schemas/") {
             return to_camel_case(name);

--- a/templates/controller.rs.txt
+++ b/templates/controller.rs.txt
@@ -22,10 +22,14 @@ pub fn handle(_req: TypedHandlerRequest<Request>) -> Response {
     // Example response:
 {{ example_json }}
     {%- endif %}
+    {% if response_is_array %}
+    Response({{ response_array_literal }})
+    {% else %}
     Response {
         {% for field in response_fields -%}
         {{ field.name }}: {{ field.value }},
         {% endfor %}
     }
+    {% endif %}
     {% endif %}
 }

--- a/templates/handler.rs.txt
+++ b/templates/handler.rs.txt
@@ -24,6 +24,8 @@ pub struct Request {
 #[derive(Debug, Serialize)]
 {% if sse %}
 pub struct Response(pub String);
+{% elif response_is_array %}
+pub struct Response(pub {{ response_array_type }});
 {% else %}
 pub struct Response {
     {% for field in response_fields -%}


### PR DESCRIPTION
## Summary
- add a recursive helper to expand `$ref` values in JSON schemas
- use helper when extracting request/response schemas
- track referenced component names while expanding
- handle array response types in generator templates
- regenerate example project

## Testing
- `cargo fmt` *(fails: `cargo-fmt` not installed)*
- `cargo test --workspace -- --nocapture` *(fails: assertion `left == right` failed)*

------
https://chatgpt.com/codex/tasks/task_e_683ce0b36388832f89ebf38495e97dc9