### PR TITLE
Update to fixed remote

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "may_minihttp"
 version = "0.1.11"
-source = "git+https://github.com/microscaler/may_minihttp.git?branch=feat%2Fconfigurable-max-headers#7140a4a95b52d565a077e74369dbc648da6c34f1"
+source = "git+https://github.com/microscaler/may_minihttp.git?branch=feat%2Fconfigurable-max-headers#e08fe1cab56221317c3983647dce04b1f360bfd5"
 dependencies = [
  "bytes",
  "httparse",

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -371,8 +371,9 @@ pub fn init_logging_with_config(config: &LogConfig) -> Result<()> {
     let mut env_filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level.as_str()));
 
-    // Suppress noisy connection close errors from may_minihttp
-    // These are normal client disconnections, not real errors
+    // may_minihttp logging: the fork at microscaler/may_minihttp now properly
+    // filters client disconnects (BrokenPipe, etc.) to not log as ERROR.
+    // Allow warn+ for actual issues, suppress debug/info noise.
     env_filter = env_filter.add_directive(
         "may_minihttp::http_server=warn"
             .parse()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update may_minihttp to a newer commit and document that only warn+ logs are emitted for the HTTP server, suppressing client disconnect noise.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6f1e8419c7b513ffc1087c28fe4a26d68f703f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->