### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/microscaler/BRRTRouter/security/code-scanning/2](https://github.com/microscaler/BRRTRouter/security/code-scanning/2)

- The fix is to add a `permissions:` block at the workflow root (top-level, just after the `name` and before `on:` or after `on:`), so it applies to _all_ jobs and ensures the GITHUB_TOKEN used for the workflow only has the least required access.
- For nearly all workflows that only run tests, upload artifacts, and do not require opening/modifying pull requests or pushing code, the minimal permission is `contents: read`.
- This involves adding a block like:
  ```yaml
  permissions:
    contents: read
  ```
  in the `.github/workflows/ci.yml` file immediately after the workflow `name:` or `on:` field.
- No further imports, methods, or definitions are needed, as this is a YAML workflow-level configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add top-level `permissions: contents: read` to `.github/workflows/ci.yml` to restrict GITHUB_TOKEN scope for all jobs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fc6efe0d12823a554666ba317cd3735ce28c950. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->