### PR TITLE
fix: set zigbuild for ubuntu

### DIFF
--- a/scripts/host-aware-build.sh
+++ b/scripts/host-aware-build.sh
@@ -28,6 +28,7 @@ use_zigbuild=true
 if [[ ${os_name} == Linux && ${arch} == x86_64 ]]; then
   use_zigbuild=false
 fi
+use_zigbuild=true
 
 if [[ ${target} == "brr" ]]; then
   if [[ ${use_zigbuild} == true ]]; then


### PR DESCRIPTION
use zigbuild for ubuntu for portability between host & container binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to use a consistent build tool across all host environments, removing conditional fallback logic to streamline the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->