### PR TITLE
fix: set zigbuild for ubuntu

### DIFF
--- a/scripts/host-aware-build.sh
+++ b/scripts/host-aware-build.sh
@@ -24,10 +24,7 @@ shift || true
 os_name=$(uname -s || echo unknown)
 arch=$(uname -m || echo unknown)
 
-use_zigbuild=true
-if [[ ${os_name} == Linux && ${arch} == x86_64 ]]; then
-  use_zigbuild=false
-fi
+# Always use zigbuild so binaries are portable between host and container.
 use_zigbuild=true
 
 if [[ ${target} == "brr" ]]; then

--- a/scripts/host-aware-build.sh
+++ b/scripts/host-aware-build.sh
@@ -28,6 +28,7 @@ use_zigbuild=true
 if [[ ${os_name} == Linux && ${arch} == x86_64 ]]; then
   use_zigbuild=false
 fi
+use_zigbuild=true
 
 if [[ ${target} == "brr" ]]; then
   if [[ ${use_zigbuild} == true ]]; then


### PR DESCRIPTION
use zigbuild for ubuntu for portability between host & container binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to standardize compilation approach across all build targets for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->